### PR TITLE
bugfix for the x64 pointer truncation issue (Fixes #8361)

### DIFF
--- a/source/ReflectiveDLLInjection/ReflectiveDLLInjection.h
+++ b/source/ReflectiveDLLInjection/ReflectiveDLLInjection.h
@@ -43,7 +43,7 @@
 #define DEREF_16( name )*(WORD *)(name)
 #define DEREF_8( name )*(BYTE *)(name)
 
-typedef DWORD (WINAPI * REFLECTIVELOADER)( VOID );
+typedef UINT_PTR (WINAPI * REFLECTIVELOADER)( VOID );
 typedef BOOL (WINAPI * DLLMAIN)( HINSTANCE, DWORD, LPVOID );
 
 #define DLLEXPORT   __declspec( dllexport ) 


### PR DESCRIPTION
Hi this should fix issue #8361 (Note I don't have a suitable meterpreter build environment at the moment so cant test, but I patched my ReflectiveDllInjection repo and tested the fix to work on that so this should be ok).

A define in ReflectiveDLLInjection.h was truncating large pointers ...facepalm :/

(Might be useful at some point to make the Meterpreter RDI stuff a git submodule to easily keep sync).
