### PR TITLE
Add 3-clause BSD license, plus dependency sub-licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,9 +18,8 @@ permitted provided that the following conditions are met:
   conditions and the following disclaimer in the documentation and/or other materials
   provided with the distribution.
 
-* Neither the name of Harmony Security nor the names of its contributors may be used to
-  endorse or promote products derived from this software without specific prior written
-  permission.
+* Neither the name of Rapid7 nor the names of its contributors may be used to endorse or
+  promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF


### PR DESCRIPTION
- Include the 3-clause BSD license for Metepreter.
- Include licenses for dependencies as specified in the original Metasploit license file.
