### PR TITLE
Change generated output file names to include platform short name

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
+IF "%1"=="clean" GOTO CLEAN
 IF "%VCINSTALLDIR%" == "" GOTO NEED_VS
 IF "%1"=="x86" GOTO BUILD_X86
 IF "%1"=="X86" GOTO BUILD_X86
@@ -24,6 +25,15 @@ PUSHD workspace
 msbuild.exe make.msbuild /target:%PLAT%
 
 POPD
+GOTO :END
+
+:CLEAN
+IF EXIST "output\x86\" (
+  del output\x86\ /S /Q
+)
+IF EXIST "output\x64\" (
+  del output\x64\ /S /Q
+)
 GOTO :END
 
 :NEED_VS

--- a/workspace/elevator/elevator.vcxproj
+++ b/workspace/elevator/elevator.vcxproj
@@ -75,8 +75,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/workspace/ext_server_espia/ext_server_espia.vcxproj
+++ b/workspace/ext_server_espia/ext_server_espia.vcxproj
@@ -73,8 +73,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/workspace/ext_server_incognito/ext_server_incognito.vcxproj
+++ b/workspace/ext_server_incognito/ext_server_incognito.vcxproj
@@ -73,8 +73,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/workspace/ext_server_lanattacks/ext_server_lanattacks.vcxproj
+++ b/workspace/ext_server_lanattacks/ext_server_lanattacks.vcxproj
@@ -71,8 +71,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/workspace/ext_server_mimikatz/ext_server_mimikatz.vcxproj
+++ b/workspace/ext_server_mimikatz/ext_server_mimikatz.vcxproj
@@ -91,11 +91,8 @@
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectName)</TargetName>
     <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</GenerateManifest>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectName).x64</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/workspace/ext_server_priv/ext_server_priv.vcxproj
+++ b/workspace/ext_server_priv/ext_server_priv.vcxproj
@@ -78,8 +78,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>

--- a/workspace/ext_server_sniffer/ext_server_sniffer.vcxproj
+++ b/workspace/ext_server_sniffer/ext_server_sniffer.vcxproj
@@ -73,8 +73,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName).x86</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/workspace/ext_server_stdapi/ext_server_stdapi.vcxproj
+++ b/workspace/ext_server_stdapi/ext_server_stdapi.vcxproj
@@ -78,8 +78,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>

--- a/workspace/metsrv/metsrv.vcxproj
+++ b/workspace/metsrv/metsrv.vcxproj
@@ -78,8 +78,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>

--- a/workspace/screenshot/screenshot.vcxproj
+++ b/workspace/screenshot/screenshot.vcxproj
@@ -73,8 +73,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules />
     <CodeAnalysisRuleAssemblies />
-    <TargetName Condition="'$(Platform)'=='Win32'">$(ProjectName)</TargetName>
-    <TargetName Condition="'$(Platform)'=='x64'">$(ProjectName).x64</TargetName>
+    <TargetName>$(ProjectName).$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
As per @jlee-r7's request I've changed the output of both 32 and 64 bit
components so that the platform is included in the file name.

I also added "make clean" to the make script.
