### PR TITLE
Add posix temp folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ source/jpeg-8/Backup/*
 
 # other VS garbage
 *.*proj.filters
+
+# ignore posix temp stuff
+posix-meterp-build-tmp/*


### PR DESCRIPTION
This folder is generated by the posix build, but isn't something that should ever be committed. Adding the gitignore means that the repo is clean after a POSIX build.
