### PR TITLE
Clean shutdown of custom meterpreter executables on migrate and exit

### DIFF
--- a/source/common/arch/win/i386/base_dispatch.c
+++ b/source/common/arch/win/i386/base_dispatch.c
@@ -195,11 +195,12 @@ DWORD remote_request_core_migrate( Remote * remote, Packet * packet )
 		thread_sigterm( serverThread );
 */
 
-		// Signal the main server thread to begin the shutdown as migration has been successfull.
+		// Signal the main server thread to begin the shutdown as migration has been successful.
 		// If the thread is not killed, the pending packet_receive prevents the new process
-		// from being able to negotiate SSL.
+		// from being able to negotiate SSL. Using thread_kill instead of thread_sigterm here
+		// results in the process not exiting properly/cleanly on Windows >= 7.
 		dprintf("[MIGRATE] Shutting down the Meterpreter thread 1 (killing the main thread)...");
-		thread_kill( serverThread );
+		thread_sigterm( serverThread );
 
 		// Wait at most 15 seconds for the event to be set letting us know that it's finished
 		// Unfortunately, its too late to do anything about a failure at this point

--- a/source/common/base_dispatch_common.c
+++ b/source/common/base_dispatch_common.c
@@ -637,7 +637,9 @@ DWORD remote_request_core_shutdown(Remote *remote, Packet *packet)
 #ifdef _WIN32
 // see note about posix above - egypt
 	dprintf("[SHUTDOWN] Shutting down the Meterpreter thread 1 (killing the main thread)...");
-	thread_kill( serverThread );
+	// Using thread_kill instead of thread_sigterm here results in the process not exiting
+	// properly/cleanly on Windows >= 7.
+	thread_sigterm( serverThread );
 #endif
 	return result;
 }


### PR DESCRIPTION
Change `thread_kill` calls for exit and migrate to `thread_sigterm`. This makes the application shut down cleanly when exiting or migrating to another process. Changes are `#ifdef`ed to `_WIN32` so they have no impact on the POSIX version.
- [ ] Exits cleanly after `exit`
- [ ] Exits cleanly after `migrate`.
- [ ] Process exits cleanly without extra channels open.
- [ ] Process exits cleanly _with_ extra channels open (eg. port forwards).
- [ ] Works with `reverse_tcp`. (The `*_http`, `*_https` are suffering from another problem.)
- [ ] Works as x86 on x86.
- [ ] Works as x86 on x64.
- [ ] Works as x64 on x64.
- [ ] Works on Windows < 7 (eg XP and Vista).
- [ ] Works on Windows >= 7 (eg 7 and 8).
