### PR TITLE
Code tidy, doxygen set up and beginnings of documentation

### DIFF
--- a/doxygen.cnf
+++ b/doxygen.cnf
@@ -768,7 +768,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = source/bionic source/jpeg-8 source/libpcap source/openssl
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -784,7 +784,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */bionic/* */jpeg-8/* */libpcap/* */openssl/* */zlib/* */rtld/lib*.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
This commit contains a few things:
- Addition of doxygen tools.
- Modification of `make.bat` to allow for `make docs`, which generates doxygen output to the `docs` folder.
- Modification of the .gitignore file to ignore the doxygen output.
- Modification of `make.bat` to attempt to look for a VS 2012 installation automatically.
- Refactor/code tidy of the Kitrap0d stuff.
- Documentation of a few files, including `base.*` and `core.*`
- Tidying up of the command declarations to hide some of the implementation detail and make them a little cleaner to read.
- Refactoring the `TLV_*` declarations so that they can be documented (and are way easier to read).

This should all build cleanly and not interfere with anything.

I wanted to get this PR going now before it got too big. Over time, documentation will be added by file pair (eg. `remote.h` and `remote.c`) so that PRs don't get too big.
