### PR TITLE
Remove strcpy calls, proper use of strncpy/strcpy_s

### DIFF
--- a/source/extensions/incognito/hash_stealer.c
+++ b/source/extensions/incognito/hash_stealer.c
@@ -50,7 +50,7 @@ DWORD request_incognito_snarf_hashes(Remote *remote, Packet *packet)
 	for (i=0;i<num_tokens;i++)
 	if (token_list[i].token)
 	{
-		get_domain_from_token(token_list[i].token, domain_name);
+		get_domain_from_token(token_list[i].token, domain_name, BUF_SIZE);
 		// If token is not "useless" local account connect to sniffer
 		if (_stricmp(domain_name, "NT AUTHORITY"))
 		{

--- a/source/extensions/incognito/list_tokens.c
+++ b/source/extensions/incognito/list_tokens.c
@@ -204,7 +204,7 @@ void process_user_token(HANDLE token, unique_user_token *uniq_tokens, DWORD *num
 		// If token user has not been seen yet then create new entry
 		if (!user_exists)
 		{
-			strcpy(uniq_tokens[*num_tokens].username, full_name);
+			strcpy_s(uniq_tokens[*num_tokens].username, MAX_USERNAME, full_name);
 			uniq_tokens[*num_tokens].token_num = 1;
 			uniq_tokens[*num_tokens].delegation_available = FALSE;
 			uniq_tokens[*num_tokens].impersonation_available = FALSE;

--- a/source/extensions/incognito/list_tokens.h
+++ b/source/extensions/incognito/list_tokens.h
@@ -8,9 +8,11 @@ typedef struct
 	HANDLE token;
 } SavedToken;
 
+#define MAX_USERNAME 256
+
 typedef struct
 {
-	char username[256];
+	char username[MAX_USERNAME];
 	int token_num;
 	BOOL delegation_available;
 	BOOL impersonation_available;

--- a/source/extensions/incognito/token_info.c
+++ b/source/extensions/incognito/token_info.c
@@ -11,7 +11,7 @@
 #include <wchar.h>
 #include "incognito.h"
 
-BOOL get_domain_from_token(HANDLE token, char *domain_to_return)
+BOOL get_domain_from_token(HANDLE token, char *domainBuffer, DWORD domainBufferSize)
 {
 	LPVOID TokenUserInfo[BUF_SIZE];
 	char username[BUF_SIZE] = "", domainname[BUF_SIZE] = "";
@@ -21,7 +21,7 @@ BOOL get_domain_from_token(HANDLE token, char *domain_to_return)
 		return FALSE;
 	LookupAccountSidA(NULL, ((TOKEN_USER*)TokenUserInfo)->User.Sid, username, &user_length, domainname, &domain_length, (PSID_NAME_USE)&sid_type);
 
-	strcpy(domain_to_return, domainname);
+	strcpy_s(domainBuffer, domainBufferSize, domainname);
 
 	return TRUE;
 }

--- a/source/extensions/incognito/token_info.h
+++ b/source/extensions/incognito/token_info.h
@@ -8,6 +8,6 @@ BOOL is_local_system();
 
 BOOL get_domain_username_from_token(HANDLE token, char *full_name_to_return);
 BOOL get_domain_groups_from_token(HANDLE token, char **group_name_array[], DWORD *num_groups);
-BOOL get_domain_from_token(HANDLE token, char *domain_to_return);
+BOOL get_domain_from_token(HANDLE token, char *domainBuffer, DWORD domainBufferSize);
 
 #endif

--- a/source/extensions/stdapi/server/fs/fs_util.c
+++ b/source/extensions/stdapi/server/fs/fs_util.c
@@ -35,8 +35,9 @@ LPSTR fs_expand_path(LPCSTR regular)
 	return expandedFilePath;
 #else /* Hack to make it work with existing code under *nix */
 	char *expandedFilePath;
-	expandedFilePath = malloc(strlen(regular)+1);
-	strcpy(expandedFilePath, regular);
+	DWORD expandedFilePathSize = strlen(regular)+1;
+	expandedFilePath = malloc(expandedFilePathSize);
+	strncpy(expandedFilePath, regular, expandedFilePathSize - 1);
 	return expandedFilePath;
 #endif
 }

--- a/source/extensions/stdapi/server/net/config/netstat.c
+++ b/source/extensions/stdapi/server/net/config/netstat.c
@@ -261,13 +261,13 @@ DWORD windows_get_tcp_table(struct connection_table **table_connection)
 					state = currentv4->dwState;
 					if ((state <= 0) || (state > 12))
 						state = 13; // points to UNKNOWN in the state array
-					strncpy(current_connection->state, tcp_connection_states[state], sizeof(current_connection->state));
-					strncpy(current_connection->protocol, "tcp", sizeof(current_connection->protocol));
+					strncpy((char*)current_connection->state, tcp_connection_states[state], sizeof(current_connection->state) - 1);
+					strncpy((char*)current_connection->protocol, "tcp", sizeof(current_connection->protocol) - 1);
 
 					// force program_name to "-" and try to get real name through GetOwnerModuleFromXXXEntry
-					strncpy(current_connection->program_name, "-", sizeof(current_connection->program_name));
+					strncpy((char*)current_connection->program_name, "-", sizeof(current_connection->program_name) - 1);
 
-					set_process_name(currentv4->dwOwningPid, current_connection->program_name, sizeof(current_connection->program_name));
+					set_process_name(currentv4->dwOwningPid, (char*)current_connection->program_name, sizeof(current_connection->program_name) - 1);
 
 					(*table_connection)->entries++;
 				}
@@ -307,13 +307,13 @@ DWORD windows_get_tcp_table(struct connection_table **table_connection)
 					state = currentv6->dwState;
 					if ((state <= 0) || (state > 12))
 						state = 13; // points to UNKNOWN in the state array
-					strncpy(current_connection->state, tcp_connection_states[state], sizeof(current_connection->state));
-					strncpy(current_connection->protocol, "tcp6", sizeof(current_connection->protocol));
+					strncpy((char*)current_connection->state, tcp_connection_states[state], sizeof(current_connection->state) - 1);
+					strncpy((char*)current_connection->protocol, "tcp6", sizeof(current_connection->protocol) - 1);
 
 					// force program_name to "-" and try to get real name through GetOwnerModuleFromXXXEntry
-					strncpy(current_connection->program_name, "-", sizeof(current_connection->program_name));
+					strncpy((char*)current_connection->program_name, "-", sizeof(current_connection->program_name) - 1);
 
-					set_process_name(currentv6->dwOwningPid, current_connection->program_name, sizeof(current_connection->program_name));
+					set_process_name(currentv6->dwOwningPid, (char*)current_connection->program_name, sizeof(current_connection->program_name));
 
 					(*table_connection)->entries++;
 				}
@@ -373,11 +373,11 @@ DWORD windows_get_udp_table_win2000_down(struct connection_table **table_connect
 				current_connection->remote_port      = 0;
 
 				// force state to ""
-				strncpy(current_connection->state, "", sizeof(current_connection->state));
-				strncpy(current_connection->protocol, "udp", sizeof(current_connection->protocol));
+				strncpy((char*)current_connection->state, "", sizeof(current_connection->state) - 1);
+				strncpy((char*)current_connection->protocol, "udp", sizeof(current_connection->protocol) - 1);
 
 				// force program_name to "-"
-				strncpy(current_connection->program_name, "-", sizeof(current_connection->program_name));
+				strncpy((char*)current_connection->program_name, "-", sizeof(current_connection->program_name) - 1);
 
 				(*table_connection)->entries++;
 			}
@@ -435,13 +435,13 @@ DWORD windows_get_udp_table(struct connection_table **table_connection)
 					current_connection->local_port       = ntohs((u_short)(currentv4->dwLocalPort & 0x0000ffff));
 					current_connection->remote_port  = 0;
 
-					strncpy(current_connection->state, "", sizeof(current_connection->state));
-					strncpy(current_connection->protocol, "udp", sizeof(current_connection->protocol));
+					strncpy((char*)current_connection->state, "", sizeof(current_connection->state) - 1);
+					strncpy((char*)current_connection->protocol, "udp", sizeof(current_connection->protocol) - 1);
 
 					// force program_name to "-" and try to get real name through GetOwnerModuleFromXXXEntry
-					strncpy(current_connection->program_name, "-", sizeof(current_connection->program_name));
+					strncpy((char*)current_connection->program_name, "-", sizeof(current_connection->program_name) - 1);
 
-					set_process_name(currentv4->dwOwningPid, current_connection->program_name, sizeof(current_connection->program_name));
+					set_process_name(currentv4->dwOwningPid, (char*)current_connection->program_name, sizeof(current_connection->program_name));
 
 					(*table_connection)->entries++;
 				}
@@ -474,13 +474,13 @@ DWORD windows_get_udp_table(struct connection_table **table_connection)
 					current_connection->local_port   = ntohs((u_short)(currentv6->dwLocalPort & 0x0000ffff));
 					current_connection->remote_port  = 0;
 
-					strncpy(current_connection->state, "", sizeof(current_connection->state));
-					strncpy(current_connection->protocol, "udp6", sizeof(current_connection->protocol));
+					strncpy((char*)current_connection->state, "", sizeof(current_connection->state) - 1);
+					strncpy((char*)current_connection->protocol, "udp6", sizeof(current_connection->protocol) - 1);
 
 					// force program_name to "-" and try to get real name through GetOwnerModuleFromXXXEntry
-					strncpy(current_connection->program_name, "-", sizeof(current_connection->program_name));
+					strncpy((char*)current_connection->program_name, "-", sizeof(current_connection->program_name) - 1);
 
-					set_process_name(currentv6->dwOwningPid, current_connection->program_name, sizeof(current_connection->program_name));
+					set_process_name(currentv6->dwOwningPid, (char*)current_connection->program_name, sizeof(current_connection->program_name));
 
 					(*table_connection)->entries++;
 				}
@@ -656,15 +656,15 @@ DWORD linux_parse_proc_net_file(char * filename, struct connection_table ** tabl
 		current_connection->uid         = uid;
 		current_connection->inode       = inode;
 		// protocol such as tcp/tcp6/udp/udp6
-		strncpy(current_connection->protocol, protocol,	sizeof(current_connection->protocol));
+		strncpy((char*)current_connection->protocol, protocol,	sizeof(current_connection->protocol) - 1);
 		if ((state < 0) && (state > 11))
 			state = 12; // points to UNKNOWN in the table
 
 		// state, number to string : 0x0A --> LISTEN
-		strncpy(current_connection->state, connection_states[state], sizeof(current_connection->state));
+		strncpy((char*)current_connection->state, connection_states[state], sizeof(current_connection->state) - 1);
 
 		// initialize every program_name to "-", will be changed if we find the good info in /proc
-		strncpy(current_connection->program_name, "-", sizeof(current_connection->program_name));
+		strncpy((char*)current_connection->program_name, "-", sizeof(current_connection->program_name) - 1);
 
 		(*table_connection)->entries++;
 	}

--- a/source/extensions/stdapi/server/sys/process/ps.c
+++ b/source/extensions/stdapi/server/sys/process/ps.c
@@ -308,7 +308,7 @@ BOOL ps_getpath( DWORD pid, char * cpExePath, DWORD dwExePathSize, char * cpExeN
 					{
 						name = strrchr( cpExePath, '\\' );
 						if( name )
-							strncpy( cpExeName, name+1, dwExeNameSize );
+							strncpy( cpExeName, name+1, dwExeNameSize - 1 );
 					}
 					success = TRUE;
 				}
@@ -639,6 +639,9 @@ void parse_status(char * buffer, struct info_process * info) {
 			strncpy(info->name, str+strlen(NAME), sizeof(info->name)-1);
 
 		if ( strncmp(str, STATE, strlen(STATE)) == 0 ) {
+			// TODO: rather than use strncpy for 1 char, why can't
+			// we just write the one char given the state is already zeroed?
+			// info->state[0] = str[strlen(STATE)];
 			strncpy(info->state, str+strlen(STATE), 1); // want only 1 char
 		}
 

--- a/source/server/win/libloader.c
+++ b/source/server/win/libloader.c
@@ -562,7 +562,7 @@ HMODULE libloader_load_library(LPCSTR name, PUCHAR buffer, DWORD bufferLength)
 	do
 	{
 		// The name of the library to load it as
-		strncpy(ctx->libname, shortName, sizeof(ctx->libname));
+		strncpy(ctx->libname, shortName, sizeof(ctx->libname) - 1);
 		ctx->liblen = (int)strlen(ctx->libname) + 1;
 
 		// The address of the raw buffer


### PR DESCRIPTION
Replaced all usages of `strcpy` with `strncpy` or `strcpy_s`.

Make sure that all usages of `strncpy` specified the correct buffer size.
