### PR TITLE
Fix meterpreter not shutting down properly

### DIFF
--- a/source/common/arch/win/i386/base_dispatch.c
+++ b/source/common/arch/win/i386/base_dispatch.c
@@ -186,12 +186,6 @@ BOOL remote_request_core_migrate( Remote * remote, Packet * packet, DWORD* pResu
 				BREAK_ON_ERROR( "[MIGRATE] inject_via_apcthread failed" )
 		}
 
-
-		//// Wait at most 15 seconds for the event to be set letting us know that it's finished
-		//// Unfortunately, its too late to do anything about a failure at this point
-		//if( WaitForSingleObjectEx( hEvent, 15000, FALSE ) != WAIT_OBJECT_0 )
-		//	dprintf("[MIGRATE] WaitForSingleObjectEx failed with no way to recover");
-
 		dwResult = ERROR_SUCCESS;
 
 	} while( 0 );
@@ -210,7 +204,8 @@ BOOL remote_request_core_migrate( Remote * remote, Packet * packet, DWORD* pResu
 	if( pResult )
 		*pResult = dwResult;
 
-	return dwResult = ERROR_SUCCESS ? TRUE : FALSE;
+	// if migration succeeded, return 'FALSE' to indicate server thread termination.
+	return dwResult = ERROR_SUCCESS ? FALSE : TRUE;
 }
 
 

--- a/source/common/base_dispatch_common.c
+++ b/source/common/base_dispatch_common.c
@@ -633,5 +633,6 @@ DWORD remote_request_core_shutdown( Remote *remote, Packet *packet, DWORD* pResu
 
 	*pResult = result;
 
-	return TRUE;
+	// We always return FALSE here to tell the server to terminate.
+	return FALSE;
 }


### PR DESCRIPTION
The work that was done a while back to fix up command dispatching allowed
inline commands to run so that the server could be told to shutdown. Those
commands that want the server to terminate (such as migrate and shutdown)
should have returned `FALSE` instead of `TRUE` to tell the server thread to
stop.

I have no idea why those values were incorrect, but it's my work so it's
definitely my fault. I will have to sick back and lick my wounds for a while.
I hate it when I'm stupid.

Thanks to Kevin Mitnick for the bug, and @todb-r7 for the investigating the
history.

Redmine: [FixRM #8696]
