### PR TITLE
Add check_key_exists registry function

### DIFF
--- a/source/extensions/stdapi/server/stdapi.c
+++ b/source/extensions/stdapi/server/stdapi.c
@@ -87,6 +87,7 @@ Command customCommands[] =
 	COMMAND_REQ( "stdapi_sys_process_thread_set_regs", request_sys_process_thread_set_regs ),
 
 	// Registry
+	COMMAND_REQ( "stdapi_registry_check_key_exists", request_registry_check_key_exists ),
 	COMMAND_REQ( "stdapi_registry_load_key", request_registry_load_key ),
 	COMMAND_REQ( "stdapi_registry_unload_key", request_registry_unload_key ),
 	COMMAND_REQ( "stdapi_registry_open_key", request_registry_open_key ),
@@ -121,10 +122,7 @@ Command customCommands[] =
 	COMMAND_REQ( "stdapi_net_config_get_netstat", request_net_config_get_netstat ),
 
 #ifdef WIN32
-	{ "stdapi_net_config_get_proxy",
-	  { request_net_config_get_proxy_config,			  { 0 }, 0 },
-	  { EMPTY_DISPATCH_HANDLER                                     },
-	},
+	COMMAND_REQ( "stdapi_net_config_get_proxy", request_net_config_get_proxy_config),
 	// Resolve
 	COMMAND_REQ( "stdapi_net_resolve_host", request_resolve_host ),
 	COMMAND_REQ( "stdapi_net_resolve_hosts", request_resolve_hosts ),

--- a/source/extensions/stdapi/server/sys/registry/registry.h
+++ b/source/extensions/stdapi/server/sys/registry/registry.h
@@ -17,5 +17,6 @@ DWORD request_registry_enum_value(Remote *remote, Packet *packet);
 DWORD request_registry_delete_value(Remote *remote, Packet *packet);
 DWORD request_registry_load_key(Remote *remote, Packet *packet);
 DWORD request_registry_unload_key(Remote *remote, Packet *packet);
+DWORD request_registry_check_key_exists(Remote *remote, Packet *packet);
 
 #endif


### PR DESCRIPTION
MSF side has been attempting to open keys to see if they exist, which isn't fantastic as it results in an error. This change adds a function which indicates to the caller if the given reg key exists.

I also updated the `stdapi_net_config_get_proxy` command declaration to use the appropriate macro.
### Verification
- [x] Check missing key works on x86
- [x] Check existing key works on x86
- [x] Check missing key works on x64
- [x] Check existing key works on x64

MSF side of this PR is [over here](https://github.com/rapid7/metasploit-framework/pull/2686)
