### PR TITLE
Add support for getting environment variable values

### DIFF
--- a/source/extensions/stdapi/server/stdapi.c
+++ b/source/extensions/stdapi/server/stdapi.c
@@ -107,6 +107,7 @@ Command customCommands[] =
 	COMMAND_REQ( "stdapi_sys_config_sysinfo", request_sys_config_sysinfo ),
 	COMMAND_REQ( "stdapi_sys_config_rev2self", request_sys_config_rev2self ),
 	COMMAND_REQ( "stdapi_sys_config_getprivs", request_sys_config_getprivs ),
+	COMMAND_REQ( "stdapi_sys_config_getenv", request_sys_config_getenv ),
 #ifdef _WIN32
 	COMMAND_REQ( "stdapi_sys_config_steal_token", request_sys_config_steal_token ),
 	COMMAND_REQ( "stdapi_sys_config_drop_token", request_sys_config_drop_token ),

--- a/source/extensions/stdapi/server/sys/config/config.h
+++ b/source/extensions/stdapi/server/sys/config/config.h
@@ -1,6 +1,7 @@
 #ifndef _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_SYS_CONFIG_CONFIG_H
 #define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_SYS_CONFIG_CONFIG_H
 
+DWORD request_sys_config_getenv(Remote *remote, Packet *packet);
 DWORD request_sys_config_getuid(Remote *remote, Packet *packet);
 DWORD request_sys_config_sysinfo(Remote *remote, Packet *packet);
 DWORD request_sys_config_rev2self(Remote *remote, Packet *packet);

--- a/source/extensions/stdapi/stdapi.h
+++ b/source/extensions/stdapi/stdapi.h
@@ -308,6 +308,15 @@
 				TLV_META_TYPE_STRING,      \
 				TLV_TYPE_EXTENSION_STDAPI, \
 				1044)
+
+// Environment stuff
+/*! @brief TLV that maps to an environment variable name. */
+#define TLV_TYPE_ENV_VARIABLE    MAKE_CUSTOM_TLV(TLV_META_TYPE_STRING, TLV_TYPE_EXTENSION_STDAPI, 1100)
+/*! @brief TLV that maps to an environment value. */
+#define TLV_TYPE_ENV_VALUE       MAKE_CUSTOM_TLV(TLV_META_TYPE_STRING, TLV_TYPE_EXTENSION_STDAPI, 1101)
+/*! @brief TLV that groups a variable with a value. */
+#define TLV_TYPE_ENV_GROUP       MAKE_CUSTOM_TLV(TLV_META_TYPE_GROUP, TLV_TYPE_EXTENSION_STDAPI, 1102)
+
 // Net
 #define TLV_TYPE_HOST_NAME             \
 		MAKE_CUSTOM_TLV(                 \


### PR DESCRIPTION
This is a new command in the stdapi which allows the caller to pass in a set of environment variable names and retrieve a hash of the names and values. Missing or unknown values are ignored.

Associated [MSF PR is over here](https://github.com/rapid7/metasploit-framework/pull/2689).
