### PR TITLE
Remove the lie introduced by #38

### DIFF
--- a/source/extensions/stdapi/server/sys/process/process.c
+++ b/source/extensions/stdapi/server/sys/process/process.c
@@ -1,7 +1,7 @@
 #include "precomp.h"
 #include "ps.h" // include the code for listing proceses
 
-#ifdef _WIN32 
+#ifdef _WIN32
 #include "./../session.h"
 #include "in-mem-exe.h" /* include skapetastic in-mem exe exec */
 
@@ -10,7 +10,7 @@ typedef BOOL (STDMETHODCALLTYPE FAR * LPFNCREATEENVIRONMENTBLOCK)( LPVOID  *lpEn
 typedef BOOL (STDMETHODCALLTYPE FAR * LPFNDESTROYENVIRONMENTBLOCK) ( LPVOID lpEnvironment );
 typedef BOOL (WINAPI * LPCREATEPROCESSWITHTOKENW)( HANDLE, DWORD, LPCWSTR, LPWSTR, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION );
 
-#else 
+#else
 
 #include "linux-in-mem-exe.h"
 
@@ -41,7 +41,7 @@ DWORD request_sys_process_attach(Remote *remote, Packet *packet)
 	{
 		BOOLEAN inherit = packet_get_tlv_value_bool(packet,
 				TLV_TYPE_INHERIT);
-		DWORD permission = packet_get_tlv_value_uint(packet, 
+		DWORD permission = packet_get_tlv_value_uint(packet,
 				TLV_TYPE_PROCESS_PERMS);
 
 		handle = OpenProcess(permission, inherit, pid);
@@ -98,12 +98,12 @@ DWORD request_sys_process_close(Remote *remote, Packet *packet)
 int try_open_pty(int *master, int *slave)
 {
 	int lmaster, lslave;
-	char path[512];	
+	char path[512];
 	struct termios newtio;
 
 	lmaster = open("/dev/ptmx", O_RDWR | O_NOCTTY);
 	if(lmaster == -1) return -1;
-	
+
 	dprintf("master fd is %d", lmaster);
 
 	if(grantpt(lmaster) == -1) {
@@ -131,7 +131,7 @@ int try_open_pty(int *master, int *slave)
 	*master = lmaster;
 	*slave = lslave;
 
-	if(tcgetattr(lmaster, &newtio) == -1) 
+	if(tcgetattr(lmaster, &newtio) == -1)
 		// oh well
 		return 0;
 
@@ -144,7 +144,7 @@ int try_open_pty(int *master, int *slave)
 	tcsetattr(lmaster, TCSANOW, &newtio);
 
 	return 0;
-}	
+}
 
 #endif
 
@@ -204,7 +204,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 		flags     = packet_get_tlv_value_uint(packet, TLV_TYPE_PROCESS_FLAGS);
 
 		if (packet_get_tlv(packet, TLV_TYPE_VALUE_DATA, &inMemoryData) == ERROR_SUCCESS)
-		{	
+		{
 			doInMemory = TRUE;
 			createFlags |= CREATE_SUSPENDED;
 		}
@@ -230,7 +230,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 			} while( 0 );
 		}
 
-		// If the remote endpoint provided arguments, combine them with the 
+		// If the remote endpoint provided arguments, combine them with the
 		// executable to produce a command line
 		if (path && arguments)
 		{
@@ -556,7 +556,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 
 		}
 
-		// check for failure here otherwise we can get a case where we 
+		// check for failure here otherwise we can get a case where we
 		// failed but return a process id and this will throw off the ruby side.
 		if( result == ERROR_SUCCESS )
 		{
@@ -625,14 +625,14 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 		dprintf("path: %s, arguments: %s\n", path ? path : "(null)", arguments ? arguments : "(null)");
 
 		if (packet_get_tlv(packet, TLV_TYPE_VALUE_DATA, &inMemoryData) == ERROR_SUCCESS)
-		{	
+		{
 			doInMemory = TRUE;
 		}
 
 		// how to handle a single string argument line? we don't have a lexer/parser to
-		// correctly handle stuff like quotes, etc. could dumbly parse on white space to 
-		// build arguments for execve. revert to /bin/sh -c style execution? 
-		// XXX.. don't feel like messing with it atm	
+		// correctly handle stuff like quotes, etc. could dumbly parse on white space to
+		// build arguments for execve. revert to /bin/sh -c style execution?
+		// XXX.. don't feel like messing with it atm
 
 		idx = 0;
 		if(arguments) {
@@ -650,7 +650,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 			path = "/bin/sh";
 		} else {
 			argv[idx++] = path;
-		}	
+		}
 		argv[idx++] = NULL;
 
 		//for (i = 0; i < idx; i++) {
@@ -700,7 +700,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 			} else {
 				// fall back to pipes if there is no tty
 				// Allocate the stdin and stdout pipes
-				if(pipe(&in) || pipe(&out)) 
+				if(pipe(&in) || pipe(&out))
 				{
 					channel_destroy(newChannel, NULL);
 
@@ -728,7 +728,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 			if( (devnull = open("/dev/null", O_RDONLY) ) == -1) {
 				// XXX This is possible, due to chroots etc. We could close
 				// fd 0/1/2 and hope the program isn't buggy.
- 
+
 				result = GetLastError();
 				break;
 			}
@@ -750,8 +750,8 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 		case 0:
 			if (flags & PROCESS_EXECUTE_FLAG_CHANNELIZED)
 			{
-				if(have_pty) 
-				{ 
+				if(have_pty)
+				{
 					dup2(slave, 0);
 					dup2(slave, 1);
 					dup2(slave, 2);
@@ -767,7 +767,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 			}
 			for(i = 3; i < 1024; i++) close(i);
 
-			if(doInMemory) 
+			if(doInMemory)
 			{
 				int found;
 				Elf32_Ehdr *ehdr = (Elf32_Ehdr *)inMemoryData.buffer;
@@ -779,7 +779,7 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 						break;
 					}
 				}
-			
+
 				if(! found) return; // XXX, not too much we can do in this case ?
 
 				perform_in_mem_exe(argv, environ, inMemoryData.buffer, inMemoryData.header.length, phdr->p_vaddr & ~4095, ehdr->e_entry);
@@ -829,13 +829,13 @@ DWORD request_sys_process_kill(Remote *remote, Packet *packet)
 	DWORD index = 0;
 
 	while ((packet_enum_tlv(packet, index++, TLV_TYPE_PID,
-			&pidTlv) == ERROR_SUCCESS) && 
+			&pidTlv) == ERROR_SUCCESS) &&
 			(pidTlv.header.length >= sizeof(DWORD)))
 	{
 		DWORD pid = ntohl(*(LPDWORD)pidTlv.buffer);
 		HANDLE h = NULL;
 
-#ifdef _WIN32 
+#ifdef _WIN32
 		// Try to attach to the process
 		if (!(h = OpenProcess(PROCESS_TERMINATE, FALSE, pid)))
 		{
@@ -883,7 +883,7 @@ DWORD request_sys_process_get_processes( Remote * remote, Packet * packet )
 
 			priv.PrivilegeCount           = 1;
 			priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-		
+
 			if( LookupPrivilegeValue( NULL, SE_DEBUG_NAME, &priv.Privileges[0].Luid ) )
 				AdjustTokenPrivileges( hToken, FALSE, &priv, 0, NULL, NULL );
 
@@ -916,7 +916,7 @@ DWORD request_sys_process_get_processes( Remote * remote, Packet * packet )
 		packet_transmit_response( result, remote, response );
 	}
 #endif
-	
+
 	return result;
 }
 
@@ -948,10 +948,10 @@ DWORD request_sys_process_get_info(Remote *remote, Packet *packet)
 	Packet *response = packet_create_response(packet);
 
 
-#ifdef _WIN32 
-	BOOL (WINAPI *enumProcessModules)(HANDLE p, HMODULE *mod, DWORD cb, 
+#ifdef _WIN32
+	BOOL (WINAPI *enumProcessModules)(HANDLE p, HMODULE *mod, DWORD cb,
 			LPDWORD needed);
-	DWORD (WINAPI *getModuleBaseName)(HANDLE p, HMODULE mod, LPTSTR base, 
+	DWORD (WINAPI *getModuleBaseName)(HANDLE p, HMODULE mod, LPTSTR base,
 			DWORD baseSize);
 	DWORD (WINAPI *getModuleFileNameEx)(HANDLE p, HMODULE mod, LPTSTR path,
 			DWORD pathSize);
@@ -989,11 +989,11 @@ DWORD request_sys_process_get_info(Remote *remote, Packet *packet)
 		}
 
 		// Try to resolve the necessary symbols
-		if ((!((LPVOID)enumProcessModules = 
+		if ((!((LPVOID)enumProcessModules =
 				(LPVOID)GetProcAddress(psapi, "EnumProcessModules"))) ||
-		    (!((LPVOID)getModuleBaseName = 
+		    (!((LPVOID)getModuleBaseName =
 				(LPVOID)GetProcAddress(psapi, "GetModuleBaseNameA"))) ||
-		    (!((LPVOID)getModuleFileNameEx = 
+		    (!((LPVOID)getModuleFileNameEx =
 				(LPVOID)GetProcAddress(psapi, "GetModuleFileNameExA"))))
 		{
 			result = GetLastError();
@@ -1067,7 +1067,7 @@ DWORD process_channel_read(Channel *channel, Packet *request,
  * Writes data from the remote half of the channel to the process's standard
  * input handle
  */
-DWORD process_channel_write( Channel *channel, Packet *request, 
+DWORD process_channel_write( Channel *channel, Packet *request,
 		LPVOID context, LPVOID buffer, DWORD bufferSize, LPDWORD bytesWritten )
 {
 	ProcessChannelContext *ctx = (ProcessChannelContext *)context;
@@ -1101,10 +1101,6 @@ DWORD process_channel_close( Channel *channel, Packet *request, LPVOID context )
 		scheduler_signal_waitable( ctx->pStdout, Stop );
 	} else {
 #ifdef _WIN32
-		// Note: We dont close the handle ctx->pStdout as this will introduce a synchronization
-		// problem with the channels interactive thread, specifically the call to WaitForMultipleObjects
-		// will have undefined behaviour. The interactive thread will close the handle instead.
-
 		CloseHandle( ctx->pStdin );
 		CloseHandle( ctx->pStdout );
 #else
@@ -1137,7 +1133,7 @@ DWORD process_channel_interact_destroy( HANDLE waitable, LPVOID entryContext, LP
 	close( ctx->pStdin );
 	close( ctx->pStdout );
 
-  dprintf( "[PROCESS] pid %u", ctx->pProcess );
+	dprintf( "[PROCESS] pid %u", ctx->pProcess );
 	if( ctx->pProcess ) {
 		dprintf( "[PROCESS] terminating pid %u", ctx->pProcess );
 		kill( (pid_t)ctx->pProcess, 9 );
@@ -1181,13 +1177,13 @@ DWORD process_channel_interact_notify(Remote *remote, LPVOID entryContext, LPVOI
 #else
 	bytesRead = read ( ctx->pStdout, buffer, sizeof(buffer) - 1);
 
-	if ( bytesRead > 0 ) 
+	if ( bytesRead > 0 )
 
 	{
 		dprintf("bytesRead: %d, errno: %d", bytesRead, errno);
 
 		result = channel_write ( channel, remote, NULL, 0, buffer, bytesRead, NULL );
-	} 
+	}
 
 	if(bytesRead == -1) {
 		if(errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN) {
@@ -1257,7 +1253,7 @@ DWORD request_sys_process_wait(Remote *remote, Packet *packet)
 			result = ERROR_SUCCESS;
 	}
 #else
-	if( ! waitpid(handle, NULL, WNOHANG)) 
+	if( ! waitpid(handle, NULL, WNOHANG))
 	{
 		result = ERROR_SUCCESS;
 	}


### PR DESCRIPTION
See https://github.com/rapid7/meterpreter/pull/38#discussion-diff-7479287R1063

Also some whitespace cleanup since vim does it automatically.
