### PR TITLE
More README lies about build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ reason, you cannot access the internet during build, you will need to:
  - wget -O posix-meterp-build-tmp/openssl-0.9.8o.tar.gz https://www.openssl.org/source/openssl-0.9.8o.tar.gz
  - wget -O posix-meterp-build-tmp/libpcap-1.1.1.tar.gz http://www.tcpdump.org/release/libpcap-1.1.1.tar.gz
 
-Note that the 'depclean' and 'really-clean' make targets will *delete*
-these files.
+(Note that 'make clean' will *delete* these files.)
 
 Now you should be able to type `make` in the base directory, go make a
 sandwich, and come back to a working[1] meterpreter for Linux.


### PR DESCRIPTION
According to [make.bat](https://github.com/todb-r7/meterpreter/blob/master/make.bat), there's no depclean or really-clean targets, just `clean` (and `docs`).
