### PR TITLE
Fix command impersonation

### DIFF
--- a/source/common/base.c
+++ b/source/common/base.c
@@ -267,7 +267,7 @@ BOOL command_process_inline(Command *baseCommand, Command *extensionCommand, Rem
 
 #ifdef _WIN32
 				// Impersonate the thread token if needed (only on Windows)
-				if (dwIndex == 0 && remote->hServerToken != remote->hThreadToken)
+				if (remote->hServerToken != remote->hThreadToken)
 				{
 					if (!ImpersonateLoggedOnUser(remote->hThreadToken))
 					{


### PR DESCRIPTION
In a previous commit, I rejigged the way commands were overloaded, and added what appeared to be a micro-optimisation to prevent the thread from being imperonsated twice. Ultimately it wouldn't make any differnce, so why I put it in there I really don't know.

The optimisation actually resulted in a breakage in the case where base commands weren't present but extension commands were. As a result all extended commands didn't get impersonated unless they were overloading. This is not a good thing at all.

This fix removed that total stupidity and restores some level of sanity.

Apologies for my idiocy. On the plus side, no bins have been released since this merge, so as of yet, nobody has suffered.

Without the fix this would happen:

```
meterpreter > getuid
Server username: OJ-DFE0B6FE1959\bob
meterpreter > getsystem
...got system (via technique 1).
meterpreter > getuid
Server username: OJ-DFE0B6FE1959\bob
```

With the fix we get this:

```
meterpreter > getuid
Server username: OJ-DFE0B6FE1959\bob
meterpreter > getsystem
...got system (via technique 1).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
