### PR TITLE
Fix old win libloader to work under Win7 and Win8

### DIFF
--- a/source/server/win/libloader.c
+++ b/source/server/win/libloader.c
@@ -106,7 +106,7 @@ typedef struct _SHELLCODE_CTX {
 	/* Allocated memory sections */
 	DWORD				file_address;
 	DWORD				mapped_address;
-	DWORD               size_map;
+	DWORD				size_map;
 
 	/* Hook stub functions */
 	unsigned char			s_NtOpenSection[10];
@@ -276,7 +276,7 @@ NTSTATUS NTAPI m_NtMapViewOfSection(
 	if (SectionHandle == (HANDLE)ctx->mapped_address) 
 	{
 		*BaseAddress = (PVOID)ctx->mapped_address;
-		*ViewSize = ctx->mapped_address;
+		*ViewSize = ctx->size_map;
 
 		/* We assume that the image must be relocated */
 		return STATUS_IMAGE_NOT_AT_BASE;
@@ -482,7 +482,7 @@ void remove_hooks(SHELLCODE_CTX *ctx)
 	lNtOpenSection = (f_NtOpenSection)GetProcAddress(ntdll,
 			"NtOpenSection");
 	lNtClose = (f_NtClose)GetProcAddress(ntdll,
-		"NtClose");
+			"NtClose");
 
 	/* NtMapViewOfSection */
 	restore_function(ctx, (DWORD)lNtMapViewOfSection, 


### PR DESCRIPTION
This pull request tries to update the old windows meterpreter library loader to work under Win7 and Win8 when loading libraries from memory.

Actually meterpreter uses Reflective DLL Loader as its main loader on Windows. The reflective DLL loader avoids using LoadLibrary and the OS loader in order to be stealthy, which is awesome. But I found a particular situation where the old library loader was pretty useful. It was while porting some of the IE Sandbox bypasses from James Forshaw to metasploit:

https://github.com/rapid7/metasploit-framework/pull/3402
https://github.com/rapid7/metasploit-framework/pull/3403
https://github.com/rapid7/metasploit-framework/pull/3404

In order to abuse these policies weaknesses you need the vulnerable process (IE Low Privilege) to load the exploit through LoadLibrary in order to apply the sandboxing. Otherwise policies don't apply and Process Created from the IE are always Low Privilege.

That said, this pull request just tries to fix the old meterpreter library loader to work under Windows 7 and Windows 8 when loading a library from memory, so we don't need to drop the exploit lib to disk. In oder to do it:
- Adds a hook for ntdll!NtClose to avoid crashing on Windows7 (and newer versions I guess).
- Modifies the ntdll! NtMapViewOfSection hook to modify the ViewSize parameter, otherwise further loading fails under Windows 7 and newer.
## Verification steps
- [x] Use this branch to generate the Release objects
- [x] With the modified meterpreter test https://github.com/rapid7/metasploit-framework/pull/3403 and/or https://github.com/rapid7/metasploit-framework/pull/3404. They should work on Windows 7 and Windows 8.
