### PR TITLE
Change IMAGE_BASE tlv to QWORD value

### DIFF
--- a/source/extensions/stdapi/server/sys/process/image.c
+++ b/source/extensions/stdapi/server/sys/process/image.c
@@ -49,7 +49,7 @@ DWORD request_sys_process_image_load(Remote *remote, Packet *packet)
 		}
 
 		// Add the base address to the result
-		packet_add_tlv_uint(response, TLV_TYPE_IMAGE_BASE, (DWORD)base);
+		packet_add_tlv_qword(response, TLV_TYPE_IMAGE_BASE, (QWORD)base);
 
 	} while (0);
 
@@ -153,7 +153,7 @@ DWORD request_sys_process_image_unload(Remote *remote, Packet *packet)
 	DWORD result = ERROR_SUCCESS;
 
 	handle = (HANDLE)packet_get_tlv_value_qword(packet, TLV_TYPE_HANDLE);
-	base   = (LPVOID)packet_get_tlv_value_uint(packet, TLV_TYPE_IMAGE_BASE);
+	base   = (LPVOID)packet_get_tlv_value_qword(packet, TLV_TYPE_IMAGE_BASE);
 
 	do
 	{

--- a/source/extensions/stdapi/stdapi.h
+++ b/source/extensions/stdapi/stdapi.h
@@ -173,7 +173,7 @@
 				2403)
 #define TLV_TYPE_IMAGE_BASE            \
 		MAKE_CUSTOM_TLV(                 \
-				TLV_META_TYPE_UINT,        \
+				TLV_META_TYPE_QWORD,       \
 				TLV_TYPE_EXTENSION_STDAPI, \
 				2404)
 #define TLV_TYPE_IMAGE_GROUP           \


### PR DESCRIPTION
In an effort to remove all pointer truncation issues we changed a stack of UINT values to QWORDS in the TLV types. Unfortunately we missed one, and this commit is a fix for this.
