### PR TITLE
invert error check for POSIX filesytem functions

### DIFF
--- a/source/extensions/stdapi/server/fs/dir.c
+++ b/source/extensions/stdapi/server/fs/dir.c
@@ -296,7 +296,7 @@ DWORD request_fs_chdir(Remote *remote, Packet *packet)
 #ifdef _WIN32
 	else if (!SetCurrentDirectory(directory))
 #else
-	else if (!chdir(directory))
+	else if (chdir(directory))
 #endif
 		result = GetLastError();
 
@@ -327,7 +327,7 @@ DWORD request_fs_mkdir(Remote *remote, Packet *packet)
 #ifdef _WIN32
 	else if (!CreateDirectory(directory, NULL))
 #else
-	else if (!mkdir(directory, 0777))
+	else if (mkdir(directory, 0777))
 #endif
 		result = GetLastError();
 
@@ -358,7 +358,7 @@ DWORD request_fs_delete_dir(Remote *remote, Packet *packet)
 #ifdef _WIN32
 	else if (!RemoveDirectory(directory))
 #else
-	else if (!rmdir(directory))
+	else if (rmdir(directory))
 #endif
 		result = GetLastError();
 

--- a/source/extensions/stdapi/server/fs/file.c
+++ b/source/extensions/stdapi/server/fs/file.c
@@ -175,11 +175,7 @@ DWORD request_fs_file_channel_open(Remote *remote, Packet *packet)
 		// Invalid file?
 		if (!(ctx->fd = fopen(expandedFilePath, mode)))
 		{
-#ifdef _WIN32
 			res = GetLastError();
-#else
-			res = errno;
-#endif
 			break;
 		}
 
@@ -312,7 +308,7 @@ DWORD request_fs_delete_file(Remote *remote, Packet *packet)
 #ifdef _WIN32
 	else if (!DeleteFile(path))
 #else
-	else if (!unlink(path))
+	else if (unlink(path))
 #endif
 		result = GetLastError();
 
@@ -510,7 +506,7 @@ DWORD request_fs_file_move(Remote *remote, Packet *packet)
 #ifdef _WIN32
 	else if (!MoveFile(oldpath,newpath))
 #else
-	else if (!rename(oldpath,newpath))
+	else if (rename(oldpath,newpath))
 #endif
 		result = GetLastError();
 


### PR DESCRIPTION
This fixes #104, by using the correct interpretation of the return value from most of the posix file functions.
