### PR TITLE
add direct access registry methods

### DIFF
--- a/source/extensions/stdapi/server/stdapi.c
+++ b/source/extensions/stdapi/server/stdapi.c
@@ -101,6 +101,10 @@ Command customCommands[] =
 	COMMAND_REQ("stdapi_registry_query_class", request_registry_query_class),
 	COMMAND_REQ("stdapi_registry_enum_value", request_registry_enum_value),
 	COMMAND_REQ("stdapi_registry_delete_value", request_registry_delete_value),
+	COMMAND_REQ("stdapi_registry_enum_key_direct", request_registry_enum_key_direct),
+	COMMAND_REQ("stdapi_registry_enum_value_direct", request_registry_enum_value_direct),
+	COMMAND_REQ("stdapi_registry_query_value_direct", request_registry_query_value_direct),
+	COMMAND_REQ("stdapi_registry_set_value_direct", request_registry_set_value_direct),
 #endif
 
 	// Sys/config

--- a/source/extensions/stdapi/server/sys/registry/registry.h
+++ b/source/extensions/stdapi/server/sys/registry/registry.h
@@ -19,4 +19,9 @@ DWORD request_registry_load_key(Remote *remote, Packet *packet);
 DWORD request_registry_unload_key(Remote *remote, Packet *packet);
 DWORD request_registry_check_key_exists(Remote *remote, Packet *packet);
 
+DWORD request_registry_enum_key_direct(Remote *remote, Packet *packet);
+DWORD request_registry_enum_value_direct(Remote *remote, Packet *packet);
+DWORD request_registry_query_value_direct(Remote *remote, Packet *packet);
+DWORD request_registry_set_value_direct(Remote *remote, Packet *packet);
+
 #endif


### PR DESCRIPTION
This adds registry access methods that do an atomic open/<action>/close on
registry keys. They improve efficiency and safety, since we're not passing
HKEY's back and forth to enumerate or read registry keys. This better fits the
common usage patterns anyway.

This is part of the fix for https://github.com/rapid7/metasploit-framework/issues/3693