### PR TITLE
Fix linux meterpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ source/server/rtld/rtldtest
 
 # Doxygen output
 docs/*
+
+# ignore CLion files
+.idea/
+CMakeLists.txt

--- a/source/extensions/stdapi/server/stdapi.c
+++ b/source/extensions/stdapi/server/stdapi.c
@@ -105,7 +105,6 @@ Command customCommands[] =
 
 	// Sys/config
 	COMMAND_REQ("stdapi_sys_config_getuid", request_sys_config_getuid),
-	COMMAND_REQ("stdapi_sys_config_getsid", request_sys_config_getsid),
 	COMMAND_REQ("stdapi_sys_config_sysinfo", request_sys_config_sysinfo),
 	COMMAND_REQ("stdapi_sys_config_rev2self", request_sys_config_rev2self),
 	COMMAND_REQ("stdapi_sys_config_getprivs", request_sys_config_getprivs),
@@ -113,6 +112,7 @@ Command customCommands[] =
 #ifdef _WIN32
 	COMMAND_REQ("stdapi_sys_config_steal_token", request_sys_config_steal_token),
 	COMMAND_REQ("stdapi_sys_config_drop_token", request_sys_config_drop_token),
+	COMMAND_REQ("stdapi_sys_config_getsid", request_sys_config_getsid),
 #endif
 
 	// Net


### PR DESCRIPTION
/cc @bcook-r7 @OJ @todb-r7 

It's an important PR because linux meterpreter builds from master are broken. I noticed it while applying some fixes for the linux migration code. I would appreciate if someone could review/verify/land this PR! Feedback super welcome, hopefully I'm not wrong with the patch!

Long history short, building linux meterpreter  from meterpreter/master has been broken since https://github.com/rapid7/meterpreter/commit/4c8427d4b185af5dc4dade9091459fff91a77ebd

**NOTE: linux meterpreter binaries in master aren't broken, keep reading**

After the commit above, if you tried to compile linux meterpreter from master, and then you get a session, an unexpected error will arise (the session won't work as expected):

```
msf exploit(handler) > run

[*] Started reverse handler on 172.16.55.1:4444
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 172.16.55.134
[*] Meterpreter session 1 opened (172.16.55.1:4444 -> 172.16.55.134:44925) at 2015-01-01 18:39:31 -0600

meterpreter > 
[-] Failed to load extension: The core_loadlib request failed with result: 2.
```

This pull request tries to solve this. As far as I can say, the getsid command is only available for Windows meterpreter.

I guess we didn't catch this error before because we failed to build fresh binaries when changing meterpreter code :\

The last time we updated linux meterpreter binaries was this one: https://github.com/rapid7/metasploit-framework/commit/92bdf42496710b55ba75ac7b9b6bad22f6013be1 It was my fault. I updated binaries compiled from my work branch to the metasploit-framework to make testing easier :( Didn't point which after landing the meterpreter pull request, new binaries had to been build!!! :\

Anyway, looks like several pull requests had been landed before without building fresh binaries for the framework. Not sure what is the politic to build fresh binaries. But worths to make it after changes in the meterpreter source, to avoid dragging these errors, because the later they arise, the harder to spot and fix them :)

Verification
---------------

- [x] Build linux meterpreter from meterpreter/master, get a session on framework, the error I've documented here should arise.
- [x] Build linux meterpreter from this pull request, get a session, verify you can get a session without errors and the session works as expected.
- [x] Build windows binaries (32 and 64 bits), everything should work ok (specially check the getsid commnand).
- [ ] Land this pull request if there aren't stoppers. Please verify carefully! Probably @OJ eyes would be useful here, since he is the getsid pull request author :)
- [ ] Build fresh binaries for all the platforms and make PR to metasploit-framework ? (I dunno what is the politic, so just proposing to be sure the binaries are fresh and working after this PR).