### PR TITLE
Improve linux migrate reliability

### DIFF
--- a/source/common/arch/posix/unix_socket_server.c
+++ b/source/common/arch/posix/unix_socket_server.c
@@ -97,7 +97,7 @@ accept_connection(server_un *s, DWORD timeout) {
 		return ETIME;
 	}
 
-	len = sizeof(c->remote);
+	len = sizeof(struct sockaddr_un);
 	if ((c->socket = accept(s->socket, (struct sockaddr *)&(c->remote), &len)) == -1) {
 		dprintf("[UNIX SOCKET SERVER] accept failed");
 		return errno;


### PR DESCRIPTION
Some fixes for the linux migrate. The important thing, adding a nop slide to a call stub. Patching EIP with ptrace is even more dangerous thane expected :\ I am not sure 100% of the reliability problems, maybe memory alignments :?

Anyway, on my tests it makes linux migrate more reliable than the initial version. Still a "dangerous" feature, but better I think :)

Verification
---------------

- [x] make new builds with these changes
- [x] Verify you can get a linux a linux meterpreter session
- [x] Verify you can migrate (limitations and steps here: https://github.com/rapid7/metasploit-framework/pull/3594). If you want to make things easy try linux 32 bits without ptrace restrictions, for example, Ubuntu 10.04 32 bits.
- [x] Make a pull request for metasploit-framework with fresh binaries and ping me, I can help to verify land them if you need :) (If you need fresh binaries to help with verification just let me know!)

