### PR TITLE
support building on newer Linux systems and Makefile cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ source/server/rtld/lib*
 source/server/rtld/msflinker
 source/server/rtld/msflinker.bin
 source/server/rtld/rtldtest
+build.log
 
 # Doxygen output
 docs/*

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ STD_CFLAGS += -I$(LIBC)/arch-x86/include/
 STD_CFLAGS += -I$(LIBC)/kernel/arch-x86/
 STD_CFLAGS += -L$(COMPILED)
 
-GCCGOLD = $(shell (echo "int main(){}" | gcc -fuse-ld=gold -o tmp -xc - && rm -f); echo $$?)
+GCCGOLD = $(shell (echo "int main(){}" | gcc -fuse-ld=gold -o/dev/null -xc -); echo $$?)
 ifeq "$(GCCGOLD)" "0"
     STD_CFLAGS += -fuse-ld=gold
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 
-
 # Used by 'install' target. Change this to wherever your framework checkout is.
 # Doesn't have to be development. Should point to the base directory where
 # msfconsole lives.
@@ -29,62 +28,28 @@ outputs += data/meterpreter/ext_server_stdapi.lso
 outputs += data/meterpreter/ext_server_sniffer.lso
 outputs += data/meterpreter/ext_server_networkpug.lso
 
-#PCAP_CFLAGS = -march=i386 -m32 -Wl,--hash-style=sysv -fno-stack-protector -nostdinc -nostdlib -fPIC -DPIC -g -Wall -D_UNIX -D__linux__  -I$(LIBC)/include -I$(LIBC)/kernel/common/linux/ -I$(LIBC)/kernel/common/ -I$(LIBC)/arch-x86/include/ -I$(LIBC)/kernel/arch-x86/ -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t" -D_BYTE_ORDER=_LITTLE_ENDIAN -lgcc -L$(COMPILED) -fPIC -Os -lc
-PCAP_CFLAGS = \
- -Os \
- -Wl,--hash-style=sysv \
- -march=i386 \
- -m32 \
- -fno-stack-protector \
- -nostdinc \
- -nostdlib \
- -fno-builtin \
- -fPIC \
- -DPIC \
- -Wall \
- -lc \
- -I$(LIBC)/include \
- -I$(LIBC)/kernel/common/linux/ \
- -I$(LIBC)/kernel/common/ \
- -I$(LIBC)/arch-x86/include/ \
- -I$(LIBC)/kernel/arch-x86/ \
- -L$(COMPILED) \
- -Dwchar_t="char" \
- -D_SIZE_T_DECLARED \
- -DElf_Size="u_int32_t" \
- -D_BYTE_ORDER=_LITTLE_ENDIAN \
- -D_UNIX \
- -D__linux__ \
- -lgcc
+STD_CFLAGS =  -Os -m32 -march=i386 -fno-stack-protector
+STD_CFLAGS += -Wl,--hash-style=sysv -fuse-ld=gold
+STD_CFLAGS += -lc -nostdinc -nostdlib -fno-builtin -fPIC -DPIC
+STD_CFLAGS += -Dwchar_t='char' -D_SIZE_T_DECLARED -DElf_Size='u_int32_t'
+STD_CFLAGS += -D_BYTE_ORDER=_LITTLE_ENDIAN -D_UNIX -D__linux__ -lgcc
+STD_CFLAGS += -I$(LIBC)/include
+STD_CFLAGS += -I$(LIBC)/kernel/common/linux/
+STD_CFLAGS += -I$(LIBC)/kernel/common/
+STD_CFLAGS += -I$(LIBC)/arch-x86/include/
+STD_CFLAGS += -I$(LIBC)/kernel/arch-x86/
+STD_CFLAGS += -L$(COMPILED)
 
-#OSSL_CFLAGS = -Os -Wl,--hash-style=sysv -march=i386 -m32 -nostdinc -nostdlib -fno-builtin -fpic -I $(LIBC)/include -I $(LIBC)/kernel/common/linux/ -I $(LIBC)/kernel/common/ -I $(LIBC)/arch-x86/include/ -I $(LIBC)/kernel/arch-x86/  -I$(LIBC)/private -I$(LIBM)/include -DPIC -Dwchar_t='char' -D_SIZE_T_DECLARED -DElf_Size='u_int32_t' -D_BYTE_ORDER=_LITTLE_ENDIAN -L$(COMPILED) -lc
-OSSL_CFLAGS = \
- -Os \
- -Wl,--hash-style=sysv \
- -march=i386 \
- -m32 \
- -nostdinc \
- -nostdlib \
- -fno-builtin \
- -fpic \
- -DPIC \
- -lc \
- -I $(LIBC)/include \
- -I $(LIBC)/kernel/common/linux/ \
- -I $(LIBC)/kernel/common/ \
- -I $(LIBC)/arch-x86/include/ \
- -I $(LIBC)/kernel/arch-x86/ \
- -I$(LIBC)/private \
- -I$(LIBM)/include \
- -L$(COMPILED) \
- -Dwchar_t='char' \
- -D_SIZE_T_DECLARED \
- -DElf_Size='u_int32_t' \
- -D_BYTE_ORDER=_LITTLE_ENDIAN \
+PCAP_CFLAGS = $(STD_CFLAGS)
+
+OSSL_CFLAGS = $(STD_CFLAGS) -I$(LIBC)/private -I$(LIBM)/include
 
 workspace = workspace
 
 all: $(objects) $(outputs)
+
+include Makefile.ossl
+include Makefile.pcap
 
 debug: DEBUG=true
 # I'm 99% sure this is the wrong way to do this
@@ -95,95 +60,75 @@ $(COMPILED):
 	mkdir $(COMPILED)/
 
 $(COMPILED)/libc.so: $(COMPILED)
-	(cd source/bionic/libc && ARCH=x86 TOP=${ROOT} jam)
-	(cd source/bionic/libc/out/x86/ && $(MAKE) -f Makefile.msf && [ -f libbionic.so ])
-	cp source/bionic/libc/out/x86/libbionic.so $(COMPILED)/libc.so
+	@echo Building libc
+	@(cd source/bionic/libc && ARCH=x86 TOP=${ROOT} jam > build.log 2>&1 )
+	@(cd source/bionic/libc/out/x86/ && $(MAKE) -f Makefile.msf >> build.log 2>&1 && [ -f libbionic.so ])
+	@cp source/bionic/libc/out/x86/libbionic.so $(COMPILED)/libc.so
 
 $(COMPILED)/libm.so:
-	$(MAKE) -C $(LIBM) -f Makefile.msf && [ -f $(LIBM)/libm.so ]
-	cp $(LIBM)/libm.so $(COMPILED)/libm.so
+	@echo Building libm
+	@$(MAKE) -C $(LIBM) -f Makefile.msf > build.log 2>&1 && [ -f $(LIBM)/libm.so ]
+	@cp $(LIBM)/libm.so $(COMPILED)/libm.so
 
 $(COMPILED)/libdl.so:
-	$(MAKE) -C $(BIONIC)/libdl && [ -f $(BIONIC)/libdl/libdl.so ]
-	cp $(BIONIC)/libdl/libdl.so $(COMPILED)/libdl.so
-
-$(COMPILED)/libcrypto.so: $(build_tmp)/openssl-0.9.8za/libssl.so
-	cp $(build_tmp)/openssl-0.9.8za/libcrypto.so source/bionic/compiled/libcrypto.so
-
-$(COMPILED)/libssl.so: $(build_tmp)/openssl-0.9.8za/libssl.so
-	cp $(build_tmp)/openssl-0.9.8za/libssl.so source/bionic/compiled/libssl.so
-
-$(build_tmp)/openssl-0.9.8za/libssl.so:
-	[ -d $(build_tmp) ] || mkdir $(build_tmp)
-	[ -f $(build_tmp)/openssl-0.9.8za.tar.gz ] || wget -O $(build_tmp)/openssl-0.9.8za.tar.gz https://www.openssl.org/source/openssl-0.9.8za.tar.gz
-	[ -d $(build_tmp)/openssl-0.9.8za ] || tar -C $(build_tmp)/ -xzf $(build_tmp)/openssl-0.9.8za.tar.gz
-	(cd $(build_tmp)/openssl-0.9.8za &&                                                       \
-		cat Configure | grep -v 'linux-msf' | \
-		sed -e 's#my %table=(#my %table=(     \
-			"linux-msf", "gcc:$(OSSL_CFLAGS) -DL_ENDIAN -DTERMIO -Wall::-D_REENTRANT::$(OSSL_CFLAGS) -ldl:BN_LLONG $${x86_gcc_des} $${x86_gcc_opts}:$${x86_elf_asm}:dlfcn:linux-shared:$(OSSL_CFLAGS) -fPIC::.so.\\$$\\$$(SHLIB_MAJOR).\\$$\\$$(SHLIB_MINOR)",\
-		#;' > Configure-msf;\
-		cp Configure-msf Configure && chmod +x Configure && \
-		grep linux-msf Configure && \
-		./Configure --prefix=/tmp/out threads shared no-hw no-dlfcn no-zlib no-krb5 no-idea 386 linux-msf \
-	)
-	(cd $(build_tmp)/openssl-0.9.8za && $(MAKE) depend all ; [ -f libssl.so.0.9.8 -a -f libcrypto.so.0.9.8 ] )
-
-$(COMPILED)/libpcap.so: $(build_tmp)/libpcap-1.1.1/libpcap.so.1.1.1
-	cp $(build_tmp)/libpcap-1.1.1/libpcap.so.1.1.1 $(COMPILED)/libpcap.so
-
-$(build_tmp)/libpcap-1.1.1/libpcap.so.1.1.1:
-	[ -d $(build_tmp) ] || mkdir $(build_tmp)
-	[ -f $(build_tmp)/libpcap-1.1.1.tar.gz ] || wget -O $(build_tmp)/libpcap-1.1.1.tar.gz http://www.tcpdump.org/release/libpcap-1.1.1.tar.gz
-	[ -f $(build_tmp)/libpcap-1.1.1/configure ] || tar -C $(build_tmp) -xzf $(build_tmp)/libpcap-1.1.1.tar.gz
-	(cd $(build_tmp)/libpcap-1.1.1 && ./configure --disable-bluetooth --without-bluetooth --without-usb --disable-usb --without-can --disable-can --without-usb-linux --disable-usb-linux --without-libnl)
-	echo '#undef HAVE_DECL_ETHER_HOSTTON' >> $(build_tmp)/libpcap-1.1.1/config.h
-	echo '#undef HAVE_SYS_BITYPES_H' >> $(build_tmp)/libpcap-1.1.1/config.h
-	echo '#undef PCAP_SUPPORT_CAN' >> $(build_tmp)/libpcap-1.1.1/config.h
-	echo '#undef PCAP_SUPPORT_USB' >> $(build_tmp)/libpcap-1.1.1/config.h
-	echo '#undef HAVE_ETHER_HOSTTON'  >> $(build_tmp)/libpcap-1.1.1/config.h
-	echo '#define _STDLIB_H this_works_around_malloc_definition_in_grammar_dot_c' >> $(build_tmp)/libpcap-1.1.1/config.h
-	(cd $(build_tmp)/libpcap-1.1.1 && patch -p0 < $(cwd)/source/libpcap/pcap_nametoaddr_fix.diff)
-	(cd $(build_tmp)/libpcap-1.1.1 && patch -p0 < $(cwd)/source/libpcap/pcap-linux.diff)
-	sed -i -e s/pcap-usb-linux.c//g -e s/fad-getad.c/fad-gifc.c/g $(build_tmp)/libpcap-1.1.1/Makefile
-	sed -i -e s^"CC = gcc"^"CC = gcc $(PCAP_CFLAGS)"^g $(build_tmp)/libpcap-1.1.1/Makefile
-	$(MAKE) -C $(build_tmp)/libpcap-1.1.1
-
+	@echo Building libdl
+	@$(MAKE) -C $(BIONIC)/libdl > build.log && [ -f $(BIONIC)/libdl/libdl.so ]
+	@cp $(BIONIC)/libdl/libdl.so $(COMPILED)/libdl.so
 
 data/meterpreter/msflinker_linux_x86.bin: source/server/rtld/msflinker.bin
 	cp source/server/rtld/msflinker.bin data/meterpreter/msflinker_linux_x86.bin
 
-source/server/rtld/msflinker.bin: $(COMPILED)/libc.so
+source/server/rtld/msflinker.bin: $(COMPILED)/libc.so \
+	$(wildcard source/server/*.h) \
+	$(wildcard source/server/*.c)
 	$(MAKE) -C source/server/rtld
 
-$(workspace)/metsrv/libmetsrv_main.so: $(COMPILED)/libsupport.so
+$(workspace)/metsrv/libmetsrv_main.so: $(COMPILED)/libsupport.so \
+	$(wildcard source/server/*.h) \
+	$(wildcard source/server/*.c)
 	$(MAKE) -C $(workspace)/metsrv
 
 $(COMPILED)/libmetsrv_main.so: $(workspace)/metsrv/libmetsrv_main.so
 	cp $(workspace)/metsrv/libmetsrv_main.so $(COMPILED)/libmetsrv_main.so
 
-$(workspace)/common/libsupport.so:
+$(workspace)/common/libsupport.so: \
+	$(wildcard source/common/*.h) \
+	$(wildcard source/common/*.c)
 	$(MAKE) -C $(workspace)/common
 
 $(COMPILED)/libsupport.so: $(workspace)/common/libsupport.so
 	cp $(workspace)/common/libsupport.so $(COMPILED)/libsupport.so
 
-$(workspace)/ext_server_sniffer/ext_server_sniffer.so: $(COMPILED)/libpcap.so
+$(workspace)/ext_server_sniffer/ext_server_sniffer.so: \
+	$(wildcard source/extensions/sniffer/*.h) \
+	$(wildcard source/extensions/sniffer/*.c) \
+	$(COMPILED)/libpcap.so
 	$(MAKE) -C $(workspace)/ext_server_sniffer
 
-data/meterpreter/ext_server_sniffer.lso: $(workspace)/ext_server_sniffer/ext_server_sniffer.so
-	cp $(workspace)/ext_server_sniffer/ext_server_sniffer.so data/meterpreter/ext_server_sniffer.lso
+data/meterpreter/ext_server_sniffer.lso: \
+	$(workspace)/ext_server_sniffer/ext_server_sniffer.so
+	cp $(workspace)/ext_server_sniffer/ext_server_sniffer.so \
+		data/meterpreter/ext_server_sniffer.lso
 
-$(workspace)/ext_server_stdapi/ext_server_stdapi.so:
+$(workspace)/ext_server_stdapi/ext_server_stdapi.so: \
+	$(wildcard source/extensions/stdapi/*.h) \
+	$(wildcard source/extensions/stdapi/*.c)
 	$(MAKE) -C $(workspace)/ext_server_stdapi
 
-data/meterpreter/ext_server_stdapi.lso: $(workspace)/ext_server_stdapi/ext_server_stdapi.so
-	cp $(workspace)/ext_server_stdapi/ext_server_stdapi.so data/meterpreter/ext_server_stdapi.lso
+data/meterpreter/ext_server_stdapi.lso: \
+	$(workspace)/ext_server_stdapi/ext_server_stdapi.so
+	cp $(workspace)/ext_server_stdapi/ext_server_stdapi.so \
+		data/meterpreter/ext_server_stdapi.lso
 
-$(workspace)/ext_server_networkpug/ext_server_networkpug.so:
+$(workspace)/ext_server_networkpug/ext_server_networkpug.so: \
+	$(wildcard source/extensions/networkpug/*.h) \
+	$(wildcard source/extensions/networkpug/*.c)
 	$(MAKE) -C $(workspace)/ext_server_networkpug
 
-data/meterpreter/ext_server_networkpug.lso: $(workspace)/ext_server_networkpug/ext_server_networkpug.so
-	cp $(workspace)/ext_server_networkpug/ext_server_networkpug.so data/meterpreter/ext_server_networkpug.lso
+data/meterpreter/ext_server_networkpug.lso: \
+    $(workspace)/ext_server_networkpug/ext_server_networkpug.so
+	cp $(workspace)/ext_server_networkpug/ext_server_networkpug.so \
+		data/meterpreter/ext_server_networkpug.lso
 
 
 install: $(outputs)
@@ -200,17 +145,6 @@ depclean:
 	find source/bionic/ -name '*.so' -print0 | xargs -0 rm -f 2>/dev/null
 	rm -f source/bionic/lib*/*.so
 	rm -rf source/openssl/lib/linux/i386/
-	rm -rf $(build_tmp)
-
-clean-pcap:
-	#(cd $(build_tmp)/libpcap-1.1.1/ && make clean)
-	# This avoids the pcap target trying to patch the same file more than once.
-	# It's a pretty small tar, so untar'ing goes pretty quickly anyway, in
-	# contrast to openssl.
-	rm -r $(build_tmp)/libpcap-1.1.1 || true
-
-clean-ssl:
-	make -C $(build_tmp)/openssl-0.9.8za/ clean
 
 really-clean: clean clean-ssl clean-pcap depclean
 

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ outputs += data/meterpreter/ext_server_sniffer.lso
 outputs += data/meterpreter/ext_server_networkpug.lso
 
 STD_CFLAGS =  -Os -m32 -march=i386 -fno-stack-protector
-STD_CFLAGS += -Wl,--hash-style=sysv -fuse-ld=gold
-STD_CFLAGS += -lc -nostdinc -nostdlib -fno-builtin -fPIC -DPIC
+STD_CFLAGS += -Wl,--hash-style=sysv
+STD_CFLAGS += -lc -lm -nostdinc -nostdlib -fno-builtin -fPIC -DPIC
 STD_CFLAGS += -Dwchar_t='char' -D_SIZE_T_DECLARED -DElf_Size='u_int32_t'
 STD_CFLAGS += -D_BYTE_ORDER=_LITTLE_ENDIAN -D_UNIX -D__linux__ -lgcc
 STD_CFLAGS += -I$(LIBC)/include
@@ -39,6 +39,11 @@ STD_CFLAGS += -I$(LIBC)/kernel/common/
 STD_CFLAGS += -I$(LIBC)/arch-x86/include/
 STD_CFLAGS += -I$(LIBC)/kernel/arch-x86/
 STD_CFLAGS += -L$(COMPILED)
+
+GCCGOLD = $(shell (echo "int main(){}" | gcc -fuse-ld=gold -o tmp -xc - && rm -f); echo $$?)
+ifeq "$(GCCGOLD)" "0"
+    STD_CFLAGS += -fuse-ld=gold
+endif
 
 PCAP_CFLAGS = $(STD_CFLAGS)
 
@@ -143,11 +148,13 @@ depclean:
 	rm -f source/bionic/lib*/*.o
 	find source/bionic/ -name '*.a' -print0 | xargs -0 rm -f 2>/dev/null
 	find source/bionic/ -name '*.so' -print0 | xargs -0 rm -f 2>/dev/null
+	find . -name 'build.log' | xargs rm -f
 	rm -f source/bionic/lib*/*.so
 	rm -rf source/openssl/lib/linux/i386/
 
 really-clean: clean clean-ssl clean-pcap depclean
 
+distclean: really-clean
 
 .PHONY: clean clean-ssl clean-pcap really-clean debug
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -35,7 +35,7 @@ LDFLAGS += -Wl,--hash-style=sysv
 
 # Specify the gold linker because newer versions of the BFD linker strip
 # important symbols from the shared libraries.
-GCCGOLD = $(shell (echo "int main(){}" | gcc -fuse-ld=gold -o tmp -xc - && rm -f); echo $$?)
+GCCGOLD = $(shell (echo "int main(){}" | gcc -fuse-ld=gold -o/dev/null -xc -); echo $$?)
 ifeq "$(GCCGOLD)" "0"
     LDFLAGS += -fuse-ld=gold
 endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,43 @@
+.SUFFIXES: .S .c
+
+CC = gcc
+AR = ar
+RM = rm
+
+CFLAGS =  -nostdinc -nostdlib
+CFLAGS += -I $(ROOT)/source/bionic/libc/include
+CFLAGS += -I $(ROOT)/source/bionic/libc/kernel/common/linux/
+CFLAGS += -I $(ROOT)/source/bionic/libc/kernel/common/
+CFLAGS += -I $(ROOT)/source/bionic/libc/arch-x86/include/
+CFLAGS += -I $(ROOT)/source/bionic/libc/kernel/arch-x86/
+CFLAGS += -I $(ROOT)/source/common
+CFLAGS += -I $(ROOT)/source/openssl/include
+CFLAGS += -I $(ROOT)/source/common/malloc
+CFLAGS += -I $(ROOT)/source/common/crypto
+CFLAGS += -I $(ROOT)/source/common/stdlib
+CFLAGS += -I $(ROOT)/source/common/zlib
+CFLAGS += -I $(ROOT)/source/libpcap
+CFLAGS += -Dwchar_t='char' -D_SIZE_T_DECLARED -DElf_Size='u_int32_t'
+CFLAGS += -D_BYTE_ORDER=_LITTLE_ENDIAN
+CFLAGS += -D_UNIX -DMALLOC_PRODUCTION
+CFLAGS += -D_POSIX_C_SOURCE=200809 -D__BSD_VISIBLE=1 -D__XSI_VISIBLE=1 -D__linux__
+CFLAGS += -fno-stack-protector -fno-builtin
+CFLAGS += -march=i386 -m32
+CFLAGS += -g -Os
+CFLAGS += -DPIC -fPIC
+
+LDFLAGS = -lgcc -lc
+LDFLAGS += -L$(ROOT)/source/bionic/compiled
+
+# Specify that we only want sysv aka DT_HASH hash tables, not DT_GNU_HASH,
+# because that's what msflinker (modified bionic linker) can handle
+LDFLAGS += -Wl,--hash-style=sysv
+
+# Specify the gold linker because newer versions of the BFD linker strip
+# important symbols from the shared libraries.
+LDFLAGS += -fuse-ld=gold
+
+%.o: %.c Makefile
+	@echo [CC] $@
+	@$(CC) $(CFLAGS) -o $@ -c $<
+

--- a/Makefile.common
+++ b/Makefile.common
@@ -35,7 +35,10 @@ LDFLAGS += -Wl,--hash-style=sysv
 
 # Specify the gold linker because newer versions of the BFD linker strip
 # important symbols from the shared libraries.
-LDFLAGS += -fuse-ld=gold
+GCCGOLD = $(shell (echo "int main(){}" | gcc -fuse-ld=gold -o tmp -xc - && rm -f); echo $$?)
+ifeq "$(GCCGOLD)" "0"
+    LDFLAGS += -fuse-ld=gold
+endif
 
 %.o: %.c Makefile
 	@echo [CC] $@

--- a/Makefile.ossl
+++ b/Makefile.ossl
@@ -1,0 +1,30 @@
+OSSL_VERS = 0.9.8za
+
+$(COMPILED)/libcrypto.so: $(build_tmp)/openssl-$(OSSL_VERS)/libssl.so
+	@echo Installing libcrypto
+	@cp $(build_tmp)/openssl-$(OSSL_VERS)/libcrypto.so source/bionic/compiled/libcrypto.so
+
+$(COMPILED)/libssl.so: $(build_tmp)/openssl-$(OSSL_VERS)/libssl.so
+	@echo Installing libssl
+	@cp $(build_tmp)/openssl-$(OSSL_VERS)/libssl.so source/bionic/compiled/libssl.so
+
+$(build_tmp)/openssl-$(OSSL_VERS)/libssl.so:
+	@echo Building OpenSSL
+	@[ -d $(build_tmp) ] || mkdir $(build_tmp)
+	@[ -f $(build_tmp)/openssl-$(OSSL_VERS).tar.gz ] || wget -O $(build_tmp)/openssl-$(OSSL_VERS).tar.gz https://www.openssl.org/source/openssl-$(OSSL_VERS).tar.gz
+	@[ -d $(build_tmp)/openssl-$(OSSL_VERS) ] || tar -C $(build_tmp)/ -xzf $(build_tmp)/openssl-$(OSSL_VERS).tar.gz
+	@(cd $(build_tmp)/openssl-$(OSSL_VERS) &&                                                       \
+		cat Configure | grep -v 'linux-msf' | \
+		sed -e 's#my %table=(#my %table=(     \
+			"linux-msf", "gcc:$(OSSL_CFLAGS) -DL_ENDIAN -DTERMIO -Wall::-D_REENTRANT::$(OSSL_CFLAGS) -ldl:BN_LLONG $${x86_gcc_des} $${x86_gcc_opts}:$${x86_elf_asm}:dlfcn:linux-shared:$(OSSL_CFLAGS) -fPIC::.so.\\$$\\$$(SHLIB_MAJOR).\\$$\\$$(SHLIB_MINOR)",\
+		#;' > Configure-msf;\
+		cp Configure-msf Configure && \
+		chmod +x Configure && \
+		./Configure --prefix=/tmp/out threads shared no-hw no-dlfcn \
+	          no-zlib no-krb5 no-idea 386 linux-msf > config.log 2>&1 \
+	)
+	@(cd $(build_tmp)/openssl-$(OSSL_VERS) && $(MAKE) depend all > build.log 2>&1; \
+	  [ -f libssl.so.0.9.8 -a -f libcrypto.so.0.9.8 ] )
+
+clean-ssl:
+	rm -fr $(build_tmp)/openssl-$(OSSL_VERS) $(COMPILED)/libcrypto.so $(COMPILED)/libssl.so

--- a/Makefile.pcap
+++ b/Makefile.pcap
@@ -1,0 +1,29 @@
+PCAP_VERSION=1.1.1
+
+$(COMPILED)/libpcap.so: $(build_tmp)/libpcap-$(PCAP_VERSION)/libpcap.so.$(PCAP_VERSION)
+	cp $(build_tmp)/libpcap-$(PCAP_VERSION)/libpcap.so.$(PCAP_VERSION) $(COMPILED)/libpcap.so
+
+$(build_tmp)/libpcap-$(PCAP_VERSION)/libpcap.so.$(PCAP_VERSION):
+	[ -d $(build_tmp) ] || mkdir $(build_tmp)
+	[ -f $(build_tmp)/libpcap-$(PCAP_VERSION).tar.gz ] || wget -O $(build_tmp)/libpcap-$(PCAP_VERSION).tar.gz http://www.tcpdump.org/release/libpcap-$(PCAP_VERSION).tar.gz
+	[ -f $(build_tmp)/libpcap-$(PCAP_VERSION)/configure ] || tar -C $(build_tmp) -xzf $(build_tmp)/libpcap-$(PCAP_VERSION).tar.gz
+	(cd $(build_tmp)/libpcap-$(PCAP_VERSION) && ./configure --disable-bluetooth --without-bluetooth --without-usb --disable-usb --without-can --disable-can --without-usb-linux --disable-usb-linux --without-libnl > build.log)
+	echo '#undef HAVE_DECL_ETHER_HOSTTON' >> $(build_tmp)/libpcap-$(PCAP_VERSION)/config.h
+	echo '#undef HAVE_SYS_BITYPES_H' >> $(build_tmp)/libpcap-$(PCAP_VERSION)/config.h
+	echo '#undef PCAP_SUPPORT_CAN' >> $(build_tmp)/libpcap-$(PCAP_VERSION)/config.h
+	echo '#undef PCAP_SUPPORT_USB' >> $(build_tmp)/libpcap-$(PCAP_VERSION)/config.h
+	echo '#undef HAVE_ETHER_HOSTTON'  >> $(build_tmp)/libpcap-$(PCAP_VERSION)/config.h
+	echo '#define _STDLIB_H this_works_around_malloc_definition_in_grammar_dot_c' >> $(build_tmp)/libpcap-$(PCAP_VERSION)/config.h
+	(cd $(build_tmp)/libpcap-$(PCAP_VERSION) && patch -p0 < $(cwd)/source/libpcap/pcap_nametoaddr_fix.diff)
+	(cd $(build_tmp)/libpcap-$(PCAP_VERSION) && patch -p0 < $(cwd)/source/libpcap/pcap-linux.diff)
+	(cd $(build_tmp)/libpcap-$(PCAP_VERSION) && patch -p1 < $(cwd)/source/libpcap/longjmp.diff)
+	sed -i -e s/pcap-usb-linux.c//g -e s/fad-getad.c/fad-gifc.c/g $(build_tmp)/libpcap-$(PCAP_VERSION)/Makefile
+	sed -i -e s^"CC = gcc"^"CC = gcc $(PCAP_CFLAGS)"^g $(build_tmp)/libpcap-$(PCAP_VERSION)/Makefile
+	$(MAKE) -C $(build_tmp)/libpcap-$(PCAP_VERSION) >> build.log
+
+clean-pcap:
+	#(cd $(build_tmp)/libpcap-$(PCAP_VERSION)/ && make clean)
+	# This avoids the pcap target trying to patch the same file more than once.
+	# It's a pretty small tar, so untar'ing goes pretty quickly anyway, in
+	# contrast to openssl.
+	rm -fr $(COMPILED)/libpcap.so $(build_tmp)/libpcap-$(PCAP_VERSION)

--- a/README.md
+++ b/README.md
@@ -98,20 +98,27 @@ You will need:
  - wget
  - flex
 
-Meterpreter requires libpcap-1.1.1 and OpenSSL 0.9.8o sources, which it
+On Ubuntu 14.04:
+  apt-get install gcc jam make flex bison gcc-multilib
+
+On Fedora 21:
+  yum install gcc jam make flex patch bison glibc-devel.i686 libgcc.i686
+
+Meterpreter requires libpcap-1.1.1 and OpenSSL 0.9.8za sources, which it
 will download automatically during the build process. If for some
 reason, you cannot access the internet during build, you will need to:
- - wget -O posix-meterp-build-tmp/openssl-0.9.8o.tar.gz https://www.openssl.org/source/openssl-0.9.8o.tar.gz
- - wget -O posix-meterp-build-tmp/libpcap-1.1.1.tar.gz http://www.tcpdump.org/release/libpcap-1.1.1.tar.gz
 
-(Note that 'make clean' will *delete* these files.)
+ - wget -O pzasix-meterp-build-tmp/zapenssl-0.9.8za.tar.gz \
+    https://www.zapenssl.zarg/szaurce/zapenssl-0.9.8za.tar.gz
+
+ - wget -O posix-meterp-build-tmp/libpcap-1.1.1.tar.gz \
+    http://www.tcpdump.org/release/libpcap-1.1.1.tar.gz
 
 Now you should be able to type `make` in the base directory, go make a
 sandwich, and come back to a working[1] meterpreter for Linux.
 
 [1] For some value of "working."  Meterpreter in POSIX environments is
 not considered stable.  It does stuff, but expect occasional problems.
-
 
 Testing
 =======

--- a/source/common/arch/posix/base_inject.c
+++ b/source/common/arch/posix/base_inject.c
@@ -1,8 +1,8 @@
 /*!
  * @file posix/base_inject.c
  * @brief Definition for functions which provide meterpreter library injection.
- * @details These functions are used in order to migrate meterpreter, using 
- *          ptrace to debug the new process host, allocate memory for the 
+ * @details These functions are used in order to migrate meterpreter, using
+ *          ptrace to debug the new process host, allocate memory for the
  *          meterpreter stage and a new stack, and give control. If something
  *          fails while migration, it should be able to restore the new host
  *          process and continue execution. Once migration is completed, the
@@ -85,7 +85,7 @@ UCHAR call_stub[] =
  * @retval 0 Indicates success.
  */
 LONG
-save_state(LONG pid, state *s) {	
+save_state(LONG pid, state *s) {
 	LONG result = 0;
 	LONG i = 0;
 
@@ -214,7 +214,8 @@ execute_stub(LONG pid, unsigned long addr, unsigned long *stub, ULONG stub_size)
  * @retval 0 indicates success.
  */
 LONG
-allocate(LONG pid, struct user_regs_struct *regs, unsigned long addr, size_t length) {
+allocate(LONG pid, struct user_regs_struct *regs, unsigned long addr, size_t length)
+{
 	unsigned long *alloc_code = (unsigned long *)mmap_stub;
 	unsigned long *addr_ptr = (unsigned long *)(mmap_stub + MMAP_ADDR_POS);
 	size_t *length_ptr = (size_t *)(mmap_stub + MMAP_LENGTH_POS);
@@ -229,12 +230,12 @@ allocate(LONG pid, struct user_regs_struct *regs, unsigned long addr, size_t len
 	addr_ptr[0] = addr;
 	length_ptr[0] = length;
 
-	result =	execute_stub(pid, regs->eip, alloc_code, code_size);
+	result = execute_stub(pid, regs->eip, alloc_code, code_size);
 	if (result != 0)
 		return result;
 
 	if (wait_trap(pid) == FALSE)
-		return ECANCELED; // We don't know what failed in the remote process 		
+		return ECANCELED; // We don't know what failed in the remote process
 
 	result = getregs(pid, regs);
 	if (result != 0)
@@ -262,7 +263,7 @@ call(LONG pid, struct user_regs_struct *regs, unsigned long addr) {
 	if (regs == NULL) {
 		return ERROR_INVALID_PARAMETER;
 	}
-	
+
 	// Fix call stub with entry point
 	addr_ptr[0] = addr;
 	if (debugging_enabled == 1) {
@@ -276,7 +277,7 @@ call(LONG pid, struct user_regs_struct *regs, unsigned long addr) {
 		return result;
 
 	if (wait_trap(pid) == FALSE)
-		return ECANCELED; // We don't know what failed in the remote process 		
+		return ECANCELED; // We don't know what failed in the remote process
 
 	return 0;
 }
@@ -315,7 +316,7 @@ inject_library(LONG pid, library *l) {
 	memcpy(&regs, &(s.regs), sizeof(struct user_regs_struct));
 
 	dprintf("[INJECT] Creating new code memory");
-	result = allocate(pid, &regs, NULL, CODE_SIZE);
+	result = allocate(pid, &regs, 0, CODE_SIZE);
 	dprintf("[DEBUG] result: %d", result);
 	if (result != 0)
 		goto restore;
@@ -332,7 +333,7 @@ inject_library(LONG pid, library *l) {
 	restore_state(pid, &s, 1);
 
 	dprintf("[INJECT] Creating new stack");
-  	result = allocate(pid, &regs, NULL, STACK_SIZE);
+  	result = allocate(pid, &regs, 0, STACK_SIZE);
 	if (result != 0)
 		goto restore;
 
@@ -358,7 +359,7 @@ inject_library(LONG pid, library *l) {
 	dprintf("[INJECT] Copying payload to 0x%x", regs.eax);
 	result = write_memory(pid, regs.eax, buf_ptr, library_size);
 	if (result != 0)
-		goto restore;	
+		goto restore;
 
 	dprintf("[INJECT] Fixing registers");
 	regs.esp = stack_mem;
@@ -374,11 +375,11 @@ inject_library(LONG pid, library *l) {
 
 	dprintf("[INJECT] The payload has warned successfully, migration has been successfully");
 	result = detach(pid);
-	goto end;	
+	goto end;
 
 restore:
 	restore_state(pid, &s, 0);
-end:	
+end:
 	return result;
 }
 

--- a/source/common/arch/posix/unix_socket_server.c
+++ b/source/common/arch/posix/unix_socket_server.c
@@ -40,7 +40,7 @@ start_server(server_un *s, LPSTR sock_path) {
 
 	s->local.sun_family = AF_UNIX;
 
-	memset(s->local.sun_path, NULL, UNIX_PATH_MAX);
+	memset(s->local.sun_path, 0, UNIX_PATH_MAX);
 	strncpy(s->local.sun_path, sock_path, UNIX_PATH_MAX - 1);
 	unlink(s->local.sun_path);
 

--- a/source/common/base.c
+++ b/source/common/base.c
@@ -50,7 +50,7 @@ DWORD THREADCALL command_process_thread( THREAD * thread );
 Command baseCommands[] =
 {
 	// Console commands
-	{  "core_console_write",  
+	{  "core_console_write",
 		{ remote_request_core_console_write,   NULL,   { TLV_META_TYPE_STRING }, 1 | ARGUMENT_FLAG_REPEAT },
 		{ remote_response_core_console_write,  NULL,   EMPTY_TLV },
 	},
@@ -211,7 +211,7 @@ VOID command_join_threads(VOID)
  * @detail Each thread appears as a process and pthread_join don't necessarily reap it
  * threads are created using the clone syscall, so use special __WCLONE flag in waitpid.
  */
-VOID reap_zombie_thread(void * param)
+void * reap_zombie_thread(void * param)
 {
 	while(1)
 	{
@@ -219,6 +219,7 @@ VOID reap_zombie_thread(void * param)
 		// on 2.6 kernels, don't chew 100% CPU
 		usleep(500000);
 	}
+	return NULL;
 }
 #endif
 
@@ -276,7 +277,7 @@ BOOL command_process_inline(Command *baseCommand, Command *extensionCommand, Rem
 				}
 #endif
 
-				// Validate the arguments, if requested.  Always make sure argument 
+				// Validate the arguments, if requested.  Always make sure argument
 				// lengths are sane.
 				if (command_validate_arguments(command, packet) != ERROR_SUCCESS)
 				{
@@ -574,7 +575,7 @@ DWORD command_validate_arguments(Command *command, Packet *packet)
 {
 	PacketDispatcher *dispatcher = NULL;
 	PacketTlvType type = packet_get_type(packet);
-	DWORD res = ERROR_SUCCESS, 
+	DWORD res = ERROR_SUCCESS,
 		packetIndex, commandIndex;
 	Tlv current;
 
@@ -618,7 +619,7 @@ DWORD command_validate_arguments(Command *command, Packet *packet)
 			break;
 		}
 
-		if ((res != ERROR_SUCCESS) && 
+		if ((res != ERROR_SUCCESS) &&
 			(commandIndex < dispatcher->numArgumentTypes))
 			break;
 	}

--- a/source/common/common.h
+++ b/source/common/common.h
@@ -26,6 +26,7 @@
 #include "compat_types.h"
 
 #include <fcntl.h>
+#include <libgen.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/source/common/compat_types.h
+++ b/source/common/compat_types.h
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 
-#if defined(__FreeBSD__) 
+#if defined(__FreeBSD__)
 #include <sys/filio.h>
 #elif defined(__linux__)
 #define __va_list  __ptr_t
@@ -234,7 +234,7 @@ int local_error;
 #define WSAGetLastError()	GetLastError()
 #define	GetLastError()		(local_error != -1 ? local_error : errno)
 #define	SetLastError(x)		(local_error = (x))
-#define	__declspec(x) 
+#define	__declspec(x)
 
 #define	__try
 #define	__except(x)	if (0)

--- a/source/common/core.c
+++ b/source/common/core.c
@@ -81,8 +81,8 @@ DWORD send_core_console_write( Remote *remote, LPCSTR fmt, ... )
  */
 HANDLE core_update_thread_token( Remote *remote, HANDLE token )
 {
-	HANDLE temp = NULL;
 #ifdef _WIN32
+	HANDLE temp = NULL;
 
 	lock_acquire( remote->lock );
 	do
@@ -138,7 +138,7 @@ VOID core_update_desktop( Remote * remote, DWORD dwSessionID, char * cpStationNa
 			dwSessionID = remote->dwOrigSessionId;
 		// Assign the new session id
 		remote->dwCurrentSessionId = dwSessionID;
-	
+
 		temp_station = remote->cpCurrentStationName;
 		// A NULL station resets the station back to the origional process window station
 		if( !cpStationName )
@@ -148,7 +148,7 @@ VOID core_update_desktop( Remote * remote, DWORD dwSessionID, char * cpStationNa
 		// free the memory for the old station name  if its not one of the two active names
 		if( temp_station && temp_station != remote->cpOrigStationName && temp_station != remote->cpCurrentStationName )
 			free( temp_station );
-		
+
 		temp_desktop = remote->cpCurrentDesktopName;
 		// A NULL station resets the desktop back to the origional process desktop
 		if( !cpDesktopName )
@@ -160,7 +160,7 @@ VOID core_update_desktop( Remote * remote, DWORD dwSessionID, char * cpStationNa
 			free( temp_desktop );
 
 	} while( 0 );
-	
+
 	lock_release( remote->lock );
 #endif
 }
@@ -270,7 +270,7 @@ DWORD packet_add_group(Packet* packet, TlvType type, Packet* groupPacket)
 
 /*!
  * @brief Create a response packet from a request.
- * @details Create a response packet from a request, referencing the requestors 
+ * @details Create a response packet from a request, referencing the requestors
  * message identifier.
  * @param request The request \c Packet to build a response for.
  * @return Pointer to a new \c Packet.
@@ -348,7 +348,7 @@ VOID packet_destroy( Packet * packet )
 				memset( buf->buffer, 0, buf->length );
 				free( buf->buffer );
 			}
-			
+
 			free( buf );
 		}
 
@@ -478,9 +478,9 @@ DWORD packet_add_tlv_bool(Packet *packet, TlvType type, BOOL val)
  */
 DWORD packet_add_tlv_group( Packet *packet, TlvType type, Tlv *entries, DWORD numEntries )
 {
-	DWORD totalSize = 0, 
+	DWORD totalSize = 0,
 		offset = 0,
-		index = 0, 
+		index = 0,
 		res = ERROR_SUCCESS;
 	PCHAR buffer = NULL;
 
@@ -583,13 +583,13 @@ DWORD packet_add_tlv_raw_compressed( Packet *packet, TlvType type, LPVOID buf, D
 
 		realLength       = compressed_length + headerLength;
 		newPayloadLength = packet->payloadLength + realLength;
-		
+
 		// Allocate/Reallocate the packet's payload
 		if( packet->payload )
 			newPayload = (PUCHAR)realloc(packet->payload, newPayloadLength);
 		else
 			newPayload = (PUCHAR)malloc(newPayloadLength);
-	
+
 		if( !newPayload )
 		{
 			result = ERROR_NOT_ENOUGH_MEMORY;
@@ -644,7 +644,7 @@ DWORD packet_add_tlv_raw( Packet *packet, TlvType type, LPVOID buf, DWORD length
 		newPayload = (PUCHAR)realloc( packet->payload, newPayloadLength );
 	else
 		newPayload = (PUCHAR)malloc( newPayloadLength );
-	
+
 	if (!newPayload)
 		return ERROR_NOT_ENOUGH_MEMORY;
 
@@ -855,7 +855,7 @@ BOOL packet_get_tlv_value_bool( Packet *packet, TlvType type )
 
 /*!
  * @brief Add an exception to a packet.
- * @details When adding an exception, both a TLV_EXCEPTION_CODE and TLV_EXCEPTION_STRING 
+ * @details When adding an exception, both a TLV_EXCEPTION_CODE and TLV_EXCEPTION_STRING
  *          are added to the packet.
  * @param packet Pointer to the packet to add the detail to.
  * @param code Exception code.
@@ -950,11 +950,11 @@ DWORD packet_find_tlv_buf( Packet *packet, PUCHAR payload, DWORD payloadLength, 
 			// if the type has been compressed, temporarily remove the compression flag as compression is to be transparent.
 			if( ( current_type & TLV_META_TYPE_COMPRESSED ) == TLV_META_TYPE_COMPRESSED )
 				current_type = (TlvType)(current_type ^ TLV_META_TYPE_COMPRESSED);
-			
+
 			// check if the types match?
 			if( (current_type != type) && (type != TLV_TYPE_ANY) )
 				continue;
-		
+
 			// Matching index?
 			if (currentIndex != index)
 			{
@@ -978,7 +978,7 @@ DWORD packet_find_tlv_buf( Packet *packet, PUCHAR payload, DWORD payloadLength, 
 					decompressed_buf = (DECOMPRESSED_BUFFER *)malloc( sizeof(DECOMPRESSED_BUFFER) );
 					if( !decompressed_buf )
 						break;
-					
+
 					// the first DWORD in a compressed buffer is the decompressed buffer length.
 					decompressed_buf->length = ntohl( *(DWORD *)tlv->buffer );
 					if( !decompressed_buf->length )
@@ -990,17 +990,17 @@ DWORD packet_find_tlv_buf( Packet *packet, PUCHAR payload, DWORD payloadLength, 
 
 					tlv->header.length -= sizeof( DWORD );
 					tlv->buffer += sizeof( DWORD );
-					
+
 					if( uncompress( (Bytef*)decompressed_buf->buffer, &decompressed_buf->length, tlv->buffer, tlv->header.length ) != Z_OK )
 						break;
-					
+
 					tlv->header.type   = tlv->header.type ^ TLV_META_TYPE_COMPRESSED;
 					tlv->header.length = decompressed_buf->length;
 					tlv->buffer        = (PUCHAR)decompressed_buf->buffer;
 
 					if( !packet->decompressed_buffers )
 						packet->decompressed_buffers = list_create();
-					
+
 					if( !packet->decompressed_buffers )
 						break;
 
@@ -1099,7 +1099,7 @@ DWORD packet_call_completion_handlers( Remote *remote, Packet *response, LPCSTR 
 	// Enumerate the completion routine list
 	for (current = packetCompletionRoutineList; current; current = current->next)
 	{
-		// Does the request id of the completion entry match the packet's request 
+		// Does the request id of the completion entry match the packet's request
 		// id?
 		if (strcmp(requestId, current->requestId))
 			continue;
@@ -1142,7 +1142,7 @@ DWORD packet_remove_completion_handler( LPCSTR requestId )
 			prev->next = next;
 		else
 			packetCompletionRoutineList = next;
-	
+
 		// Deallocate it
 		free((PCHAR)current->requestId);
 		free(current);
@@ -1207,7 +1207,7 @@ DWORD packet_transmit_via_ssl( Remote *remote, Packet *packet, PacketRequestComp
 
 	do
 	{
-		// If a completion routine was supplied and the packet has a request 
+		// If a completion routine was supplied and the packet has a request
 		// identifier, insert the completion routine into the list
 		if ((completion) &&
 		    (packet_get_tlv_string(packet, TLV_TYPE_REQUEST_ID,
@@ -1224,8 +1224,8 @@ DWORD packet_transmit_via_ssl( Remote *remote, Packet *packet, PacketRequestComp
 			PUCHAR origPayload = packet->payload;
 
 			// Encrypt
-			if ((res = crypto->handlers.encrypt(crypto, packet->payload, 
-					packet->payloadLength, &packet->payload, 
+			if ((res = crypto->handlers.encrypt(crypto, packet->payload,
+					packet->payloadLength, &packet->payload,
 					&packet->payloadLength)) !=
 					ERROR_SUCCESS)
 			{
@@ -1242,14 +1242,14 @@ DWORD packet_transmit_via_ssl( Remote *remote, Packet *packet, PacketRequestComp
 
 		idx = 0;
 		while( idx < sizeof(packet->header))
-		{ 
+		{
 			// Transmit the packet's header (length, type)
 			res = SSL_write(
-				remote->ssl, 
-				(LPCSTR)(&packet->header) + idx, 
+				remote->ssl,
+				(LPCSTR)(&packet->header) + idx,
 				sizeof(packet->header) - idx
 			);
-			
+
 			if(res <= 0) {
 				dprintf("[PACKET] transmit header failed with return %d at index %d\n", res, idx);
 				break;
@@ -1262,10 +1262,10 @@ DWORD packet_transmit_via_ssl( Remote *remote, Packet *packet, PacketRequestComp
 
 		idx = 0;
 		while( idx < packet->payloadLength)
-		{ 
+		{
 			// Transmit the packet's payload (length, type)
 			res = SSL_write(
-				remote->ssl, 
+				remote->ssl,
 				packet->payload + idx,
 				packet->payloadLength - idx
 			);
@@ -1330,7 +1330,7 @@ DWORD packet_transmit_via_http( Remote *remote, Packet *packet, PacketRequestCom
 
 	do
 	{
-		// If a completion routine was supplied and the packet has a request 
+		// If a completion routine was supplied and the packet has a request
 		// identifier, insert the completion routine into the list
 		if ((completion) &&
 		    (packet_get_tlv_string(packet, TLV_TYPE_REQUEST_ID,
@@ -1347,8 +1347,8 @@ DWORD packet_transmit_via_http( Remote *remote, Packet *packet, PacketRequestCom
 			PUCHAR origPayload = packet->payload;
 
 			// Encrypt
-			if ((res = crypto->handlers.encrypt(crypto, packet->payload, 
-					packet->payloadLength, &packet->payload, 
+			if ((res = crypto->handlers.encrypt(crypto, packet->payload,
+					packet->payloadLength, &packet->payload,
 					&packet->payloadLength)) !=
 					ERROR_SUCCESS)
 			{
@@ -1484,7 +1484,7 @@ DWORD packet_transmit_empty_response( Remote *remote, Packet *packet, DWORD res 
  */
 DWORD packet_receive( Remote *remote, Packet **packet )
 {
-	DWORD headerBytes = 0, payloadBytesLeft = 0, res; 
+	DWORD headerBytes = 0, payloadBytesLeft = 0, res;
 	CryptoContext *crypto = NULL;
 	Packet *localPacket = NULL;
 	TlvHeader header;
@@ -1496,10 +1496,10 @@ DWORD packet_receive( Remote *remote, Packet **packet )
 #ifdef _UNIX
 	int local_error = -1;
 #endif
-	
+
 	if (remote->transport == METERPRETER_TRANSPORT_HTTP || remote->transport == METERPRETER_TRANSPORT_HTTPS)
 		return packet_receive_via_http( remote, packet );
-	
+
 	lock_acquire( remote->lock );
 
 	do
@@ -1521,13 +1521,13 @@ DWORD packet_receive( Remote *remote, Packet **packet )
 			}
 
 			headerBytes += bytesRead;
-	
+
 			if (headerBytes != sizeof(TlvHeader))
 				continue;
 			else
 				inHeader = FALSE;
 		}
-		
+
 		if (headerBytes != sizeof(TlvHeader))
 			break;
 
@@ -1543,7 +1543,7 @@ DWORD packet_receive( Remote *remote, Packet **packet )
 			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 			break;
 		}
-			
+
 		// Read the payload
 		while (payloadBytesLeft > 0)
 		{
@@ -1566,7 +1566,7 @@ DWORD packet_receive( Remote *remote, Packet **packet )
 
 			payloadBytesLeft -= bytesRead;
 		}
-		
+
 		// Didn't finish?
 		if (payloadBytesLeft)
 			break;
@@ -1638,7 +1638,7 @@ DWORD packet_receive( Remote *remote, Packet **packet )
  */
 DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 
-	DWORD headerBytes = 0, payloadBytesLeft = 0, res; 
+	DWORD headerBytes = 0, payloadBytesLeft = 0, res;
 	CryptoContext *crypto = NULL;
 	Packet *localPacket = NULL;
 	TlvHeader header;
@@ -1652,7 +1652,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 	HINTERNET hReq;
 	BOOL hRes;
 	DWORD retries = 5;
-	
+
 	lock_acquire( remote->lock );
 
 	do {
@@ -1675,7 +1675,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 			flags |= SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_CERT_CN_INVALID | SECURITY_FLAG_IGNORE_UNKNOWN_CA;
 			InternetSetOption(hReq, INTERNET_OPTION_SECURITY_FLAGS, &flags, flen);
 		}
-		
+
 		hRes = HttpSendRequest(hReq, NULL, 0, "RECV", 4 );
 		if (! hRes) {
 			dprintf("[PACKET RECEIVE] Failed HttpSendRequest: %d", GetLastError());
@@ -1695,7 +1695,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 			}
 
 			// If the response contains no data, this is fine, it just means the
-			// remote side had nothing to tell us. Indicate this through a 
+			// remote side had nothing to tell us. Indicate this through a
 			// ERROR_EMPTY response code so we can update the timestamp.
 			if (bytesRead == 0) {
 				SetLastError(ERROR_EMPTY);
@@ -1703,7 +1703,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 			}
 
 			headerBytes += bytesRead;
-	
+
 			if (headerBytes != sizeof(TlvHeader)) {
 				continue;
 			} else {
@@ -1713,7 +1713,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 
 		if (GetLastError() == ERROR_EMPTY)
 			break;
-		
+
 		if (headerBytes != sizeof(TlvHeader)) {
 			SetLastError(ERROR_NOT_FOUND);
 			break;
@@ -1731,7 +1731,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 			SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 			break;
 		}
-			
+
 		// Read the payload
 		retries = payloadBytesLeft;
 		while (payloadBytesLeft > 0 && retries > 0 )
@@ -1750,7 +1750,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 
 			payloadBytesLeft -= bytesRead;
 		}
-		
+
 		// Didn't finish?
 		if (payloadBytesLeft)
 			break;
@@ -1806,7 +1806,7 @@ DWORD packet_receive_http_via_wininet( Remote *remote, Packet **packet ) {
 			free(localPacket);
 	}
 
-	if (hReq) 
+	if (hReq)
 		InternetCloseHandle(hReq);
 
 	lock_release( remote->lock );

--- a/source/common/thread.c
+++ b/source/common/thread.c
@@ -11,7 +11,7 @@ int __futex_wake(volatile void *ftx, int count);
 
 #endif
 
-// thread.c contains wrappers for the primitives of locks, events and threads for use in 
+// thread.c contains wrappers for the primitives of locks, events and threads for use in
 // the multithreaded meterpreter. This is the win32/win64 implementation.
 
 /*****************************************************************************************/
@@ -142,7 +142,7 @@ BOOL event_signal( EVENT * event )
 		dprintf( "Signalling 0x%x failed %u", event->handle, GetLastError() );
 		return FALSE;
 	}
-#else 
+#else
 	event->handle = (HANDLE)1;
 	__futex_wake(&(event->handle), 1);
 #endif
@@ -189,8 +189,8 @@ BOOL event_poll( EVENT * event, DWORD timeout )
 			ts.tv_nsec -= 1000000000;
 		}
 
-		// atomically checks if event->handle is 0, if so, 
-		// it sleeps for timeout. if event->handle is 1, it 
+		// atomically checks if event->handle is 0, if so,
+		// it sleeps for timeout. if event->handle is 1, it
 		// returns straight away.
 
 		__futex_wait(&(event->handle), 0, &ts);
@@ -222,7 +222,7 @@ THREAD * thread_open( VOID )
 	if( thread != NULL )
 	{
 		memset( thread, 0, sizeof(THREAD) );
-			
+
 		thread->id      = GetCurrentThreadId();
 		thread->sigterm = event_create();
 
@@ -281,7 +281,7 @@ struct thread_conditional {
 	pthread_mutex_t suspend_mutex;
 	pthread_cond_t suspend_cond;
 	int engine_running;
-	THREADFUNK (*funk)(void *arg);
+	LPVOID (*funk)(void *arg);
 	THREAD *thread;
 };
 
@@ -292,8 +292,8 @@ void __thread_cancelled(int signo)
 }
 
 /*
- * This is the entry point for threads created with thread_create. 
- * 
+ * This is the entry point for threads created with thread_create.
+ *
  * To implement suspended threads, we need to do some messing around with
  * mutexes and conditional broadcasts ;\
  */
@@ -318,7 +318,7 @@ void *__paused_thread(void *req)
 
 	funk = tc->funk;
 	thread = tc->thread;
-	free(tc); 
+	free(tc);
 
 	if(event_poll(thread->sigterm, 0) == TRUE) {
 		/*
@@ -327,7 +327,7 @@ void *__paused_thread(void *req)
 		return NULL;
 	}
 
-	return funk(thread);	
+	return funk(thread);
 }
 #endif
 
@@ -337,7 +337,7 @@ void *__paused_thread(void *req)
 THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2, LPVOID param3 )
 {
 	THREAD * thread = NULL;
-	
+
 	if( funk == NULL )
 		return NULL;
 
@@ -371,7 +371,7 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2, LPVOID pa
 
 #else
 	// PKS, this is fucky.
-	// we need to use conditionals to implement this. 
+	// we need to use conditionals to implement this.
 
 	thread->thread_started = FALSE;
 
@@ -386,13 +386,13 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2, LPVOID pa
 			free(thread);
 			return NULL;
 		}
-		
+
 		memset( tc, 0, sizeof(struct thread_conditional));
 
 		pthread_mutex_init(&tc->suspend_mutex, NULL);
 		pthread_cond_init(&tc->suspend_cond, NULL);
 
-		tc->funk = funk;		
+		tc->funk = funk;
 		tc->thread = thread;
 
 		thread->suspend_thread_data = (void *)(tc);
@@ -450,10 +450,10 @@ BOOL thread_sigterm( THREAD * thread )
 	ret = event_signal( thread->sigterm );
 
 #ifndef _WIN32
-	/* 
-	 * If we sig term a thread before it's started execution, we will leak memory / not be 
+	/*
+	 * If we sig term a thread before it's started execution, we will leak memory / not be
 	 * able to join on the thread, etc.
-	 * 
+	 *
 	 * Therefore, we need to start the thread executing before calling thread_join
 	 */
 	if(thread->thread_started != TRUE) {
@@ -509,7 +509,7 @@ BOOL thread_join( THREAD * thread )
 
 	return FALSE;
 #else
-	if(pthread_join(thread->pid, NULL) == 0) 
+	if(pthread_join(thread->pid, NULL) == 0)
 		return TRUE;
 
 	return FALSE;
@@ -524,7 +524,7 @@ BOOL thread_destroy( THREAD * thread )
 {
 	if( thread == NULL )
 		return FALSE;
-	
+
 	event_destroy( thread->sigterm );
 
 #ifdef _WIN32

--- a/source/common/thread.h
+++ b/source/common/thread.h
@@ -61,7 +61,7 @@ typedef struct _THREAD
 	LPVOID parameter1;
 	LPVOID parameter2;
 	LPVOID parameter3;
-#ifndef _WIN32 
+#ifndef _WIN32
 	void *suspend_thread_data;
 	pthread_t pid;
 	int thread_started;

--- a/source/extensions/sniffer/sniffer.c
+++ b/source/extensions/sniffer/sniffer.c
@@ -32,7 +32,7 @@ Command customCommands[] =
 #ifdef _WIN32
 
 // include the Reflectiveloader() function, we end up linking back to the metsrv.dll's Init function
-// but this doesnt matter as we wont ever call DLL_METASPLOIT_ATTACH as that is only used by the 
+// but this doesnt matter as we wont ever call DLL_METASPLOIT_ATTACH as that is only used by the
 // second stage reflective dll inject payload and not the metsrv itself when it loads extensions.
 #include "../../ReflectiveDLLInjection/dll/src/ReflectiveLoader.c"
 
@@ -175,14 +175,14 @@ char *packet_filter;
 #define PktDestroy(x) free((void *)(x))
 #define PktGetPacketSize(x) (((PeterPacket *)(x))->h.caplen)
 
-DWORD PktGetId(DWORD handle, DWORD *thi)
+DWORD PktGetId(void *handle, DWORD *thi)
 {
 	PeterPacket *pp = (PeterPacket *)(handle);
 	*thi = pp->h.ts.tv_sec;
 	return pp->h.ts.tv_usec;
 }
 
-DWORD PktGetTimeStamp(DWORD handle, DWORD *thi)
+DWORD PktGetTimeStamp(void *handle, DWORD *thi)
 {
 	__int64_t i64;
 	PeterPacket *pp = (PeterPacket *)(handle);
@@ -371,7 +371,7 @@ DWORD request_sniffer_interfaces(Remote *remote, Packet *packet)
 			// netlink_get_interfaces suceeded
 			for (i = 0; i < ifaces->entries; i++)
 			{
-				aidx_bigendian		 = htonl(ifaces->ifaces[i].index); 
+				aidx_bigendian		 = htonl(ifaces->ifaces[i].index);
 				entries[0].header.type   = TLV_TYPE_UINT;
 				entries[0].header.length = sizeof(uint32_t);
 				entries[0].buffer        = (PUCHAR)&aidx_bigendian;
@@ -407,7 +407,7 @@ DWORD request_sniffer_interfaces(Remote *remote, Packet *packet)
 
 				packet_add_tlv_group(response, TLV_TYPE_SNIFFER_INTERFACES, entries, 8);
 			}
-		}		
+		}
 
 	} while(0);
 
@@ -780,7 +780,7 @@ DWORD request_sniffer_capture_start(Remote *remote, Packet *packet)
 
 #endif
 
-		j->pkts = (HANDLE *)calloc(maxp, sizeof(HANDLE));
+		j->pkts = calloc(maxp, sizeof(*(j->pkts)));
 		if (j->pkts == NULL) {
 #ifdef _WIN32
 			AdpCloseAdapter(j->adp);

--- a/source/extensions/sniffer/sniffer.h
+++ b/source/extensions/sniffer/sniffer.h
@@ -33,7 +33,11 @@ typedef struct capturejob
 	unsigned int cur_bytes;
 	unsigned int mtu;
 	HANDLE adp;
+#ifdef _WIN32
 	HANDLE *pkts;
+#else
+	struct PeterPacket **pkts;
+#endif
 	unsigned char *dbuf;
 	unsigned int dlen;
 	unsigned int didx;
@@ -105,6 +109,6 @@ typedef struct capturejob
 		MAKE_CUSTOM_TLV(					\
 			TLV_META_TYPE_STRING,				\
 			TLV_TYPE_EXTENSION_SNIFFER,			\
-			TLV_EXTENSIONS + 10)	
+			TLV_EXTENSIONS + 10)
 
 #endif

--- a/source/libpcap/longjmp.diff
+++ b/source/libpcap/longjmp.diff
@@ -1,0 +1,29 @@
+diff -u libpcap-1.1.1/gencode.c libpcap-1.1.1.tmp/gencode.c
+--- libpcap-1.1.1/gencode.c	2010-03-11 19:56:54.000000000 -0600
++++ libpcap-1.1.1.tmp/gencode.c	2015-01-12 15:17:48.283017369 -0600
+@@ -139,7 +138,6 @@
+ 		(void)vsnprintf(pcap_geterr(bpf_pcap), PCAP_ERRBUF_SIZE,
+ 		    fmt, ap);
+ 	va_end(ap);
+-	longjmp(top_ctx, 1);
+ 	/* NOTREACHED */
+ }
+
+@@ -425,17 +423,6 @@
+ 	root = NULL;
+ 	bpf_pcap = p;
+ 	init_regs();
+-	if (setjmp(top_ctx)) {
+-#ifdef INET6
+-		if (ai != NULL) {
+-			freeaddrinfo(ai);
+-			ai = NULL;
+-		}
+-#endif
+-		lex_cleanup();
+-		freechunks();
+-		return (-1);
+-	}
+
+ 	netmask = mask;
+

--- a/source/server/rtld/Makefile
+++ b/source/server/rtld/Makefile
@@ -1,25 +1,30 @@
 
-CFLAGS+=-I${PWD}/hack
-CFLAGS+= -I ../../bionic/libc/include -I ../../bionic/libc/kernel/common/linux/ -I ../../bionic/libc/kernel/common/ -I ../../bionic/libc/arch-x86/include/
-CFLAGS+= -I ../../bionic/libc/kernel/arch-x86/ -I../../source/server/elf/headers -I../../bionic/libc/private -fPIC -DPIC
-CFLAGS+= -nostdinc -nostdlib -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t" -DANDROID_X86_LINKER
-CFLAGS+= -DMETSRV_RTLD -D_BYTE_ORDER=_LITTLE_ENDIAN
+CFLAGS +=-I${PWD}/hack
+CFLAGS += -I ../../bionic/libc/include
+CFLAGS += -I ../../bionic/libc/kernel/common/linux/
+CFLAGS += -I ../../bionic/libc/kernel/common/
+CFLAGS += -I ../../bionic/libc/arch-x86/include/
+CFLAGS += -I ../../bionic/libc/kernel/arch-x86/
+CFLAGS += -I../../source/server/elf/headers
+CFLAGS += -I../../bionic/libc/private
+CFLAGS += -fPIC -DPIC
+CFLAGS += -nostdinc -nostdlib
+CFLAGS += -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t"
+CFLAGS += -DANDROID_X86_LINKER -DMETSRV_RTLD -D_BYTE_ORDER=_LITTLE_ENDIAN
+CFLAGS += -march=i386 -m32
 
-CFLAGS+= -march=i386 -m32
+OBJ = msflinker.o basic_libc.o syscall.o linker_format.o dlfcn.o zlib.o metsrv_rtld.o
 
-OBJ=msflinker.o basic_libc.o syscall.o linker_format.o dlfcn.o zlib.o metsrv_rtld.o
-
-compiled=../../bionic/compiled
+compiled = ../../bionic/compiled
 
 # These are all generated from their .so counterparts below
-HEADERS=libc.h       \
+HEADERS=libc.h           \
 	libm.h           \
 	libcrypto.h      \
 	libssl.h         \
 	libsupport.h     \
 	libmetsrv_main.h \
 	libpcap.h
-
 
 all: msflinker msflinker.bin rtldtest
 
@@ -46,10 +51,12 @@ rtldtest: rtldtest.c msflinker
 	$(CC) -march=i386 -m32 -o rtldtest rtldtest.c -DEP=`objdump -f msflinker | grep start | awk '{ print $$3 }'`
 
 .S.o:
-	$(CC) $(CFLAGS) -c $<
+	@echo [CC] $@
+	@$(CC) $(CFLAGS) -c $<
 
 .c.o:
-	$(CC) $(CFLAGS) -c $<
+	@echo [CC] $@
+	@$(CC) $(CFLAGS) -c $<
 
 clean:
 	rm -f $(HEADERS)

--- a/source/server/rtld/elf2bin.c
+++ b/source/server/rtld/elf2bin.c
@@ -59,21 +59,21 @@ int main(int argc, char **argv)
 
 	ehdr = (Elf32_Ehdr *)data;
 	phdr = (Elf32_Phdr *)(data + ehdr->e_phoff);
-	
+
 	printf("data @ %p, mapping @ %p\n", data, mapping);
 
 	for(i = 0; i < ehdr->e_phnum; i++, phdr++) {
 		if(phdr->p_type == PT_LOAD) {
-			if(base == NULL) {
+			if(base == (Elf32_Addr)NULL) {
 				base = phdr->p_vaddr & ~4095;
 			}
 
 			source = data + (phdr->p_offset & ~4095);
 			dest = mapping + ((phdr->p_vaddr - base) & ~4095);
-			len = phdr->p_filesz + (phdr->p_vaddr & 4095);	
+			len = phdr->p_filesz + (phdr->p_vaddr & 4095);
 			printf("memcpy(%p, %p, %08x)\n", dest, source, len);
 			memcpy(dest, source, len);
-			
+
 			used += (phdr->p_memsz + (phdr->p_vaddr & 4095) + 4095) & ~4095 ;
 		}
 	}

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -1,17 +1,15 @@
-SUBDIRS = common metsrv ext_server_stdapi ext_server_sniffer ext_server_networkpug
-
-CFLAGS+= -march=i386 -m32
+SUBDIRS = common metsrv
+SUBDIRS += ext_server_stdapi
+SUBDIRS += ext_server_sniffer
+SUBDIRS += ext_server_networkpug
 
 subdirs:
 	for dir in $(SUBDIRS); do \
 	$(MAKE) -C $$dir; \
 	done
 
-
-
 .PHONY:
 clean:
 	for dir in $(SUBDIRS); do \
 	$(MAKE) -C $$dir clean; \
 	done
-

--- a/workspace/common/Makefile
+++ b/workspace/common/Makefile
@@ -1,71 +1,19 @@
-.SUFFIXES: .S .c
+ROOT = ../..
 
-SOURCEPATH=../../source/common
-SSLPATH=../../source/openssl/include
-MALLOC_PATH=../../source/common/malloc
-XOR_PATH=../../source/common/crypto
-STDLIBPATH=../../source/common/stdlib
-ZLIB_PATH=../../source/common/zlib
+include $(ROOT)/Makefile.common
 
+VPATH =  $(ROOT)/source/common:
+VPATH += $(ROOT)/source/common/crypto:
+VPATH += $(ROOT)/source/common/arch/posix:
+VPATH += $(ROOT)/source/common/zlib
 
-CFLAGS=-nostdinc -nostdlib
-CFLAGS+= -I ../../source/bionic/libc/include -I ../../source/bionic/libc/kernel/common/linux/ -I ../../source/bionic/libc/kernel/common/ 
-CFLAGS+= -I ../../source/bionic/libc/arch-x86/include/
-CFLAGS+= -I ../../source/bionic/libc/kernel/arch-x86/ 
-CFLAGS+= -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t" -D_BYTE_ORDER=_LITTLE_ENDIAN
-CFLAGS+= -lgcc -L../../source/bionic/compiled
+objects = args.o base.o unix_socket_server.o passfd_server.o ptrace.o \
+          base_inject.o base_dispatch.o base_dispatch_common.o buffer.o \
+          channel.o common.o core.o list.o remote.o thread.o xor.o zlib.o
 
-CFLAGS+= -D_UNIX -I$(SOURCEPATH) -I$(MALLOC_PATH) -I$(XOR_PATH) -DMALLOC_PRODUCTION -DPIC -I$(SSLPATH) -I$(STDLIBPATH) -I$(ZLIB_PATH)
-CFLAGS+= -g -fPIC -Os -D_POSIX_C_SOURCE=200809 -D__BSD_VISIBLE=1 -D__XSI_VISIBLE=1
-
-CFLAGS+= -march=i386 -m32
-
-
-CC=gcc
-AR=ar
-RM=rm
-
-objects = args.o base.o unix_socket_server.o passfd_server.o ptrace.o base_inject.o base_dispatch.o base_dispatch_common.o buffer.o \
-	channel.o common.o core.o list.o remote.o thread.o xor.o zlib.o
-
-
-
-####### check platform
-OSNAME= $(shell uname -s)
-ARCH= $(shell uname -m | sed 's/i[456]86/i386/g')
-
-ifeq ($(OSNAME), FreeBSD)
-	OS= bsd
-	libc_objects+= cerror.o
-else
-	CFLAGS+= -fno-stack-protector -D__linux__
-	CFLAGS+=  -D_POSIX_C_SOURCE=200809 -D__BSD_VISIBLE=1 -D__XSI_VISIBLE=1 
-	OS=$(OSNAME)
-#	requires tls - which we don't have
-#	libc_objects+= errno.o
-endif
-
-BASEVPATH=../../source/common:../../source/common/crypto:../../source/common/arch/posix:../../source/common/zlib:
-OSVPATH= ../../source/common/arch/$(OS)
-ARCHVPATH= $(OSVPATH)/$(ARCH)
-VPATH=$(BASEVPATH):$(OSVPATH):$(ARCHVPATH)
-
-CFLAGS+= -I$(ARCHVPATH)
-
-
-all: libsupport.so
-
-debug: CFLAGS+=-ggdb
-debug: all
-
-
-libsupport.so: $(objects)
-	# Specify that we only want sysv aka DT_HASH hash tables, not DT_GNU_HASH,
-	# because that's what msflinker (modified bionic linker) can handle
-	$(CC) -Wl,--hash-style=sysv $(CFLAGS) -shared $(objects) -lc -lssl -lcrypto -o $@ 
+libsupport.so: $(objects) Makefile
+	@echo [LD] $@
+	@$(CC) $(CFLAGS) $(LDFLAGS) -shared $(objects) -lc -lssl -lcrypto -o $@
 
 clean:
-	$(RM) -f *.o *.a *.so zlib/zlib.o
-
-.PHONY: clean
-
+	$(RM) -f *.o *.a *.so *.a

--- a/workspace/ext_server_networkpug/Makefile
+++ b/workspace/ext_server_networkpug/Makefile
@@ -1,43 +1,16 @@
-VPATH=../../source/extensions/networkpug
+ROOT = ../..
 
-OPENSSL=../../source/openssl/include
-COMMON=../../source/common
-SERVER=../../source/server
-PCAP=../../source/libpcap
-LIBC=../../source/bionic/libc
+include ../../Makefile.common
 
-CFLAGS=-nostdinc -nostdlib -fPIC -DPIC -Wall
-CFLAGS+=-D_UNIX -D__linux__
-CFLAGS+=-I$(COMMON) -I$(SERVER) -I$(OPENSSL) -I$(PCAP)
-CFLAGS+= -I$(LIBC)/include -I$(LIBC)/kernel/common/linux/ -I$(LIBC)/kernel/common/ -I$(LIBC)/arch-x86/include/
-CFLAGS+= -I$(LIBC)/kernel/arch-x86/
-CFLAGS+= -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t"
-CFLAGS+= -D_BYTE_ORDER=_LITTLE_ENDIAN
-CFLAGS+= -lgcc -L../../source/bionic/compiled
-CFLAGS+= -I../../source/extensions/networkpug -lc -lpcap -lsupport -lmetsrv_main
+VPATH = ../../source/extensions/networkpug
 
-CFLAGS+= -march=i386 -m32 -Os
-
-#LDFLAGS= -fPIC -Bshareable -lc
-
-ifeq ($(OSNAME), FreeBSD)
-	OS= bsd
-else
-	OS=$(OSNAME)
-	CFLAGS+= -fno-stack-protector -D__linux__
-endif
+CFLAGS += -I../../source/extensions/networkpug
 
 objects = networkpug.o
 
-all: ext_server_networkpug.so
-
-debug: CFLAGS+= -ggdb
-debug: all
-
 ext_server_networkpug.so: $(objects)
-	$(CC) -Wl,--hash-style=sysv -shared $(CFLAGS) $(objects) -o $@
+	@echo [LD] $@
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(objects) -lc -lsupport -lmetsrv_main -lpcap -o $@
 
-
-.PHONY: clean debug
 clean:
-	rm -f *.o *.so *~; rm -f $(objects)
+	rm -f *.o *.so

--- a/workspace/ext_server_sniffer/Makefile
+++ b/workspace/ext_server_sniffer/Makefile
@@ -1,36 +1,17 @@
-VPATH=../../source/extensions/sniffer
+ROOT = ../..
 
-OPENSSL=../../source/openssl/include
-COMMON=../../source/common
-SERVER=../../source/server
-PCAP=../../source/libpcap
+include $(ROOT)/Makefile.common
 
-CFLAGS=-fno-stack-protector -nostdinc -nostdlib -fPIC -DPIC -g -Wall
-CFLAGS+=-D_UNIX -D__linux__
-CFLAGS+=-I${COMMON} -I${SERVER} -I${OPENSSL} -I${PCAP}
-CFLAGS+= -I ../../source/bionic/libc/include -I ../../source/bionic/libc/kernel/common/linux/ -I ../../source/bionic/libc/kernel/common/ -I ../../source/bionic/libc/arch-x86/include/
-CFLAGS+= -I ../../source/bionic/libc/kernel/arch-x86/
-CFLAGS+= -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t"
-CFLAGS+= -D_BYTE_ORDER=_LITTLE_ENDIAN
-CFLAGS+= -lgcc -L../../source/bionic/compiled
-CFLAGS+= -fPIC -Os
-CFLAGS+= -I../../source/extensions/networkpug -lc -lpcap -lsupport -lmetsrv_main
-CFLAGS+= -I.
+VPATH += $(ROOT)/source/extensions/sniffer
 
-CFLAGS+= -march=i386 -m32
+CFLAGS += -I$(ROOT)/source/extensions/networkpug
+CFLAGS += -I.
 
 objects = sniffer.o
 
-all: ext_server_sniffer.so
-
-
-debug: CFLAGS+= -ggdb
-debug: all
-
-
 ext_server_sniffer.so: $(objects)
-	$(CC) -Wl,--hash-style=sysv -shared $(CFLAGS) $(objects) -lpcap -lssl -o $@
+	@echo [LD] $@
+	@$(CC) $(CFLAGS) $(LDFLAGS) -shared $(objects) -lpcap -lssl -lc -lsupport -lmetsrv_main -o $@
 
-.PHONY: clean debug
 clean:
-	rm -f *.o *.so *~; rm -f $(objects)
+	rm -f *.o *.so

--- a/workspace/ext_server_stdapi/Makefile
+++ b/workspace/ext_server_stdapi/Makefile
@@ -1,29 +1,10 @@
-VPATH=../../source/extensions/stdapi
+ROOT = ../..
 
-OPENSSL=../../source/openssl/include
-COMMON=../../source/common
-SERVER=../../source/server
+include $(ROOT)/Makefile.common
 
-CFLAGS=-fno-stack-protector -nostdinc -nostdlib -fPIC -DPIC -Wall
-CFLAGS+=-D_UNIX -D__linux__
-CFLAGS+=-I${COMMON} -I${SERVER} -I${OPENSSL}
-CFLAGS+= -I ../../source/bionic/libc/include -I ../../source/bionic/libc/kernel/common/linux/ -I ../../source/bionic/libc/kernel/common/ -I ../../source/bionic/libc/arch-x86/include/
-CFLAGS+= -I ../../source/bionic/libc/kernel/arch-x86/
-CFLAGS+= -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t"
-CFLAGS+= -D_BYTE_ORDER=_LITTLE_ENDIAN
-CFLAGS+= -lgcc -L../../source/bionic/compiled
-CFLAGS+= -I../../source/extensions/stdapi/server -lc -lsupport -lmetsrv_main
+VPATH = $(ROOT)/source/extensions/stdapi
 
-CFLAGS+= -march=i386 -m32 -Os
-
-#LDFLAGS= -fPIC -Bshareable -lc
-
-ifeq ($(OSNAME), FreeBSD)
-	OS= bsd
-else
-	OS=$(OSNAME)
-	CFLAGS+= -fno-stack-protector -D__linux__
-endif
+CFLAGS+= -I../../source/extensions/stdapi/server
 
 objects = \
 	server/fs/dir.o \
@@ -41,26 +22,18 @@ objects = \
 	server/sys/config/config.o \
 	server/sys/process/linux-in-mem-exe.o \
 	server/sys/process/process.o \
-	server/sys/process/ps.o \
-
-all: ext_server_stdapi.so
-
-output_dirs:
-	mkdir -p server/fs
-	mkdir -p server/net/config
-	mkdir -p server/net/socket
-	mkdir -p server/sys/config
-	mkdir -p server/sys/process
-
-debug: CFLAGS+=-ggdb
-debug: all
+	server/sys/process/ps.o
 
 ext_server_stdapi.so: output_dirs $(objects)
-	$(CC) -Wl,--hash-style=sysv -shared $(CFLAGS) $(objects) -lcrypto -o $@
+	@echo [LD] $@
+	@$(CC) $(CFLAGS) $(LDFLAGS) -shared $(objects) -lcrypto -lc -lsupport -lmetsrv_main -o $@
 
+output_dirs:
+	@mkdir -p server/fs
+	@mkdir -p server/net/config
+	@mkdir -p server/net/socket
+	@mkdir -p server/sys/config
+	@mkdir -p server/sys/process
 
-.PHONY: clean debug output_dirs
 clean:
-	rm -f *.o *.so *~
-	rm -f $(objects) ext_server_stdapi.so
-
+	@rm -fr server *.so

--- a/workspace/metsrv/Makefile
+++ b/workspace/metsrv/Makefile
@@ -1,38 +1,21 @@
+ROOT = ../..
 
-BASEVPATH=../../source/server:../../source/server/posix/
-OPENSSL=../../source/openssl/include
-COMMON=../../source/common
-SERVER=../../source/server
+include $(ROOT)/Makefile.common
 
-CFLAGS=-fno-stack-protector -nostdinc -nostdlib 
-CFLAGS+=-D_UNIX -D__linux__ 
-CFLAGS+=-I${COMMON} -I${SERVER} -I${OPENSSL}
-CFLAGS+= -I ../../source/bionic/libc/include -I ../../source/bionic/libc/kernel/common/linux/ -I ../../source/bionic/libc/kernel/common/ -I ../../source/bionic/libc/arch-x86/include/
-CFLAGS+= -I ../../source/bionic/libc/kernel/arch-x86/ 
-CFLAGS+= -Dwchar_t="char" -fno-builtin -D_SIZE_T_DECLARED -DElf_Size="u_int32_t" 
-CFLAGS+= -D_BYTE_ORDER=_LITTLE_ENDIAN
-CFLAGS+= -lgcc -L../../source/bionic/compiled
+VPATH += $(ROOT)/source/server/linux/:
+VPATH += $(ROOT)/source/common/arch/posix/:
+VPATH += $(ROOT)/source/server/posix/:
+VPATH += $(ROOT)/source/server/
 
-CFLAGS+= -march=i386 -m32
+CFLAGS += -I$(ROOT)/source/server
 
-OS=posix
-OSVPATH=../../source/common/arch/$(OS):../../source/server/linux/
-ARCHVPATH=$(OSVPATH)/$(RARCH):$(ELFARCHPATH)
-VPATH=$(BASEVPATH):$(OSVPATH):$(ARCHVPATH)
-
-objects= metsrv.o scheduler.o 
-objects+= server_setup.o remote_dispatch_common.o remote_dispatch.o netlink.o
-
-all:  libmetsrv_main.so 
-
-debug: CFLAGS+=-ggdb
-debug: all
+objects = metsrv.o scheduler.o server_setup.o remote_dispatch_common.o
+objects += remote_dispatch.o netlink.o
 
 libmetsrv_main.so: $(objects)
-	$(CC) -Wl,--hash-style=sysv -shared $(CFLAGS) -o $@ $(objects) -export-dynamic -lc -lcrypto -lssl -lgcc -ldl -lsupport
+	@echo [LD] $@
+	@$(CC) $(CFLAGS) $(LDFLAGS) -shared $(objects) -lc -lssl -lcrypto -o $@
+	@$(CC) $(CFLAGS) $(LDFLAGS) -shared $(objects) -export-dynamic -lc -lcrypto -lssl -ldl -lsupport -o $@
 
 clean:
-	@echo "ARCHVPATH= " $(ARCHVPATH) " VPATH= " $(VPATH)
-	$(RM) -f *.o *.h *.so *.gz *~ *.a libmetsrv_main.so
-
-.PHONY: clean
+	$(RM) -f *.o *.a *.so *.a


### PR DESCRIPTION
This fixes some issues building Meterpreter under recent linux distributions and quiets some of the noise to make further development feasible.

 - try to share some bits between different makefiles, make modifying global compiler flags not such a huge pain.
 - directly specify we should be using the gold rather than bpf linker
 - make compiler output largely quiet except where we care - allow warnings to actually be visible
 - don't delete downloaded tarballs with --really-clean
 - add missing dependencies between libraries (--no-add-needed/--no-copy-dt-needed-entries causes lots of trouble)
 - update readme to show what to install to build

I made minimal changes to the loader makefile - it breaks easily.
 -Os prevents if from being able to load libc, for instance

# Verification Steps

On Ubuntu 14.04 or Fedora 21 x64, try these things:
- [x] install recommended packages in the README.md file
- [x] run 'make really-clean && make && make install'
- [x] verify that it runs and installs new binaries in your metasploit-framework directory
- [x] verify that you can start a meterpreter shell
- [x] load networkpug
- [x] load sniffer

Build should look a little nicer, it stashes a lot of the 3rd party build noise into log files:
```
$ make
Building libc
Building libm
Building libdl
Building OpenSSL
Installing libcrypto
Installing libssl
make -C workspace/common
make[1]: Entering directory `/home/bcook/projects/meterpreter/workspace/common'
[CC] args.o
[CC] base.o
[CC] unix_socket_server.o
[CC] passfd_server.o
[CC] ptrace.o
[CC] base_inject.o
[CC] base_dispatch.o
[CC] base_dispatch_common.o
[CC] buffer.o
[CC] channel.o
[CC] common.o
```

Though the extensive use of 'HANDLE' in a unix environment is imperfect, so there are lots of bad casts and things that will be solved later. My editor also auto-deletes trailing whitespace on save, so sorry in advance for the noise.