### PR TITLE
Fix issue with double-start of clipboard monitor

### DIFF
--- a/source/extensions/extapi/clipboard.c
+++ b/source/extensions/extapi/clipboard.c
@@ -1268,9 +1268,20 @@ DWORD request_clipboard_monitor_start(Remote *remote, Packet *packet)
 		dwResult = ERROR_SUCCESS;
 	} while (0);
 
-	if (dwResult != ERROR_SUCCESS)
+	if (dwResult == ERROR_ALREADY_INITIALIZED)
 	{
-		destroy_clipboard_monitor_state(pState);
+		// if we've already been initialised, then we don't want to go
+		// resetting gClipboardState back to NULL because that means
+		// the existing monitor will run indefinitely! Instead we will
+		// just simulate success here
+		dwResult = ERROR_SUCCESS;
+	}
+	else if (dwResult != ERROR_SUCCESS)
+	{
+		if (pState != NULL)
+		{
+			destroy_clipboard_monitor_state(pState);
+		}
 		gClipboardState = NULL;
 	}
 


### PR DESCRIPTION
If a user attempts to start the clipboard monitor when it is already started then the code path that is taken results in the current clipboard monitor state pointers being lost. The net effect of this is that the existing monitor thread will never be shut down. Not a good thing!

This code fixes that case so that the monitor doesn't create a new monitor thread and doesn't reset important pointers to NULL.

This change also results in a "success" status being returned to the caller. This means it looks like the clipboard monitor has been started even if it was already running. I think this is acceptable and is better than an obscure error.

@wchen-r7 reported this as an issue. Fixes #120.

## Verification

- [ ] Make sure the build is clean.
- [ ] Make sure that calling `clipboard_monitor_start` multiple times results in an indication of success.
- [ ] Make sure that after calling `clipboard_monitor_start` multiple times that the user is able to successfully shut down the monitor using `clipboard_monitor_stop`.
- [ ] Both x64 and x86 function correctly.

## Sample run
```
msf exploit(handler) > run

[*] Started reverse handler on 172.16.52.1:8000
[*] Starting the payload handler...
[*] Sending stage (972288 bytes) to 172.16.52.1
[*] Meterpreter session 2 opened (172.16.52.1:8000 -> 172.16.52.1:61173) at 2015-01-31 06:57:20 +1000

meterpreter > use extapi
Loading extension extapi...success.
meterpreter > clipboard_monitor_start
[+] Clipboard monitor started
meterpreter > clipboard_monitor_start
[+] Clipboard monitor started
meterpreter > clipboard_monitor_start
[+] Clipboard monitor started
meterpreter > clipboard_monitor_start
[+] Clipboard monitor started
meterpreter > clipboard_monitor_stop
[+] Clipboard monitor stopped
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.255.143 - Meterpreter session 2 closed.  Reason: User exit
```