### PR TITLE
make real_dprintf available even if DEBUGTRACE is not set

### DIFF
--- a/source/common/common.c
+++ b/source/common/common.c
@@ -17,7 +17,7 @@ int current_unix_timestamp(void) {
 
 	GetSystemTime(&system_time);
 	SystemTimeToFileTime(&system_time, &file_time);
-	
+
 	ularge.LowPart = file_time.dwLowDateTime;
 	ularge.HighPart = file_time.dwHighDateTime;
 	return (long)((ularge.QuadPart - 116444736000000000) / 10000000L);
@@ -47,11 +47,7 @@ int current_unix_timestamp(void) {
 int debugging_enabled;
 
 /*!
- * @brief Output a debug string to the debug console.
- * @details The function emits debug strings via `OutputDebugStringA`, hence all messages can be viewed
- *          using Visual Studio's _Output_ window, _DebugView_ from _SysInternals_, or _Windbg_.
- * @remark If we supply real_dprintf in the common.h, each .o file will have a private copy of that symbol.
- *         This leads to bloat. Defining it here means that there will only be a single implementation of it.
+ * @brief Writes debug to a temporary file based on the current PID.
  */
 void real_dprintf(char *filename, int line, const char *function, char *format, ...)
 {
@@ -73,9 +69,9 @@ retry_log:
 	if(fd <= 0) {
 		char filename[128];
 		sprintf(filename, "/tmp/meterpreter.log.%d%s", getpid(), retried ? ".retry" : "" );
-		
+
 		fd = open(filename, O_RDWR|O_TRUNC|O_CREAT|O_SYNC, 0644);
-		
+
 		if(fd <= 0) return;
 	}
 

--- a/source/common/common.h
+++ b/source/common/common.h
@@ -190,13 +190,12 @@ void real_dprintf(char *filename, int line, const char *function, char *format, 
 /*! @brief Close a handle if not already closed and set the handle to NULL. */
 #define CLOSE_HANDLE( h )          if( h ) { DWORD dwHandleFlags; if(GetHandleInformation( h , &dwHandleFlags)) CloseHandle( h ); h = NULL; }
 
-#ifdef DEBUGTRACE
 /*!
  * @brief Output a debug string to the debug console.
  * @details The function emits debug strings via `OutputDebugStringA`, hence all messages can be viewed
  *          using Visual Studio's _Output_ window, _DebugView_ from _SysInternals_, or _Windbg_.
  */
-static void real_dprintf(char *format, ...) {
+static _inline void real_dprintf(char *format, ...) {
 	va_list args;
 	char buffer[1024];
 	va_start(args,format);
@@ -204,7 +203,6 @@ static void real_dprintf(char *format, ...) {
 	strcat_s(buffer, sizeof(buffer), "\r\n");
 	OutputDebugStringA(buffer);
 }
-#endif
 
 #endif
 

--- a/source/elevator/elevator.h
+++ b/source/elevator/elevator.h
@@ -14,7 +14,7 @@
 #define dprintf(...) do{}while(0);
 #endif
 
-static void real_dprintf(char *format, ...) {
+static _inline void real_dprintf(char *format, ...) {
 	va_list args;
 	char buffer[1024];
 	va_start(args,format);

--- a/source/extensions/kiwi/debug.h
+++ b/source/extensions/kiwi/debug.h
@@ -22,8 +22,7 @@
 /*! @brief Close a handle if not already closed and set the handle to NULL. */
 #define CLOSE_HANDLE( h )          if( h ) { DWORD dwHandleFlags; if(GetHandleInformation( h , &dwHandleFlags)) CloseHandle( h ); h = NULL; }
 
-#ifdef KIWIDEBUGTRACE
-static void real_dprintf(wchar_t *format, ...) {
+static _inline void real_dprintf(wchar_t *format, ...) {
 	va_list args;
 	wchar_t buffer[1024];
 	va_start(args,format);
@@ -31,5 +30,3 @@ static void real_dprintf(wchar_t *format, ...) {
 	wcscat_s(buffer, sizeof(buffer), L"\r\n");
 	OutputDebugStringW(buffer);
 }
-
-#endif

--- a/source/screenshot/screenshot.h
+++ b/source/screenshot/screenshot.h
@@ -14,7 +14,7 @@
 #define dprintf(...) do{}while(0);
 #endif
 
-static void real_dprintf(char *format, ...) {
+static _inline void real_dprintf(char *format, ...) {
 	va_list args;
 	char buffer[1024];
 	va_start(args,format);


### PR DESCRIPTION
By making this a static _inline, it is not necessary to guard it, since an inline is only instantiated if it is used. This also allows adding one-off debug message for use during debugging sessions, without turning
on DEBUGTRACE all over the place.

Convert a few of the extensions to also do this as well, making them perhaps slightly smaller.

I am curious why Windows builds define debug this way, vs posix that just includes it in common.c. Could I just do that instead, assuming there's no historical reason.

Finally, correct the docs in the posix version of real_dprintf.

This doesn't have any effect on the default build output.