### PR TITLE
Fix issue with POSIX bins not working

### DIFF
--- a/source/extensions/networkpug/networkpug.c
+++ b/source/extensions/networkpug/networkpug.c
@@ -76,7 +76,7 @@ void packet_handler(u_char *user, const struct pcap_pkthdr *h, const u_char *byt
 	}
 	np->packet_stream = tmp;
 
-	size = (unsigned short int *)(np->packet_stream + np->packet_stream_length);  
+	size = (unsigned short int *)(np->packet_stream + np->packet_stream_length);
 	*size = htons(h->caplen);
 	data = (unsigned char *)(np->packet_stream + np->packet_stream_length + 2);
 
@@ -438,7 +438,11 @@ Command customCommands[] =
 /*
  * Initialize the server extension
  */
+#ifdef _WIN32
 DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
+#else
+DWORD InitServerExtension(Remote *remote)
+#endif
 {
 	int peername_len;
 	struct sockaddr peername;
@@ -497,7 +501,11 @@ DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 /*
  * Deinitialize the server extension
  */
+#ifdef _WIN32
 DWORD __declspec(dllexport) DeinitServerExtension(Remote *remote)
+#else
+DWORD DeinitServerExtension(Remote *remote)
+#endif
 {
 	command_deregister_all(customCommands);
 
@@ -505,5 +513,25 @@ DWORD __declspec(dllexport) DeinitServerExtension(Remote *remote)
 	
 	lock_destroy(pug_lock);
 
+	return ERROR_SUCCESS;
+}
+
+/*!
+ * @brief Get the name of the extension.
+ * @param buffer Pointer to the buffer to write the name to.
+ * @param bufferSize Size of the \c buffer parameter.
+ * @return Indication of success or failure.
+ */
+#ifdef _WIN32
+DWORD __declspec(dllexport) GetExtensionName(char* buffer, int bufferSize)
+#else
+DWORD GetExtensionName(char* buffer, int bufferSize)
+#endif
+{
+#ifdef _WIN32
+	strncpy_s(buffer, bufferSize, "networkpug", bufferSize - 1);
+#else
+	strncpy(buffer, "networkpug", bufferSize - 1);
+#endif
 	return ERROR_SUCCESS;
 }

--- a/source/extensions/sniffer/sniffer.c
+++ b/source/extensions/sniffer/sniffer.c
@@ -1197,7 +1197,11 @@ DWORD request_sniffer_capture_dump(Remote *remote, Packet *packet)
  * @param remote Pointer to the remote instance.
  * @return Indication of success or failure.
  */
+#ifdef _WIN32
 DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
+#else
+DWORD InitServerExtension(Remote *remote)
+#endif
 {
 #ifdef _WIN32
 	// This handle has to be set before calls to command_register
@@ -1271,7 +1275,11 @@ DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
  * @param remote Pointer to the remote instance.
  * @return Indication of success or failure.
  */
+#ifdef _WIN32
 DWORD __declspec(dllexport) DeinitServerExtension(Remote *remote)
+#else
+DWORD DeinitServerExtension(Remote *remote)
+#endif
 {
 	command_register_all( customCommands );
 
@@ -1294,8 +1302,16 @@ DWORD __declspec(dllexport) DeinitServerExtension(Remote *remote)
  * @param bufferSize Size of the \c buffer parameter.
  * @return Indication of success or failure.
  */
+#ifdef _WIN32
 DWORD __declspec(dllexport) GetExtensionName(char* buffer, int bufferSize)
+#else
+DWORD GetExtensionName(char* buffer, int bufferSize)
+#endif
 {
+#ifdef _WIN32
 	strncpy_s(buffer, bufferSize, "sniffer", bufferSize - 1);
+#else
+	strncpy(buffer, "sniffer", bufferSize - 1);
+#endif
 	return ERROR_SUCCESS;
 }

--- a/source/extensions/stdapi/server/stdapi.c
+++ b/source/extensions/stdapi/server/stdapi.c
@@ -216,8 +216,16 @@ DWORD DeinitServerExtension(Remote *remote)
  * @param bufferSize Size of the \c buffer parameter.
  * @return Indication of success or failure.
  */
+#ifdef _WIN32
 DWORD __declspec(dllexport) GetExtensionName(char* buffer, int bufferSize)
+#else
+DWORD GetExtensionName(char* buffer, int bufferSize)
+#endif
 {
+#ifdef _WIN32
 	strncpy_s(buffer, bufferSize, "stdapi", bufferSize - 1);
+#else
+	strncpy(buffer, "stdapi", bufferSize - 1);
+#endif
 	return ERROR_SUCCESS;
 }

--- a/source/server/remote_dispatch_common.c
+++ b/source/server/remote_dispatch_common.c
@@ -7,6 +7,8 @@ extern HINSTANCE hAppInstance;
 
 PLIST gExtensionList = NULL;
 
+DWORD request_core_enumextcmd(Remote* pRemote, Packet* pPacket);
+
 // Dispatch table
 Command customCommands[] = 
 {
@@ -14,6 +16,56 @@ Command customCommands[] =
 	COMMAND_REQ("core_enumextcmd", request_core_enumextcmd),
 	COMMAND_TERMINATOR
 };
+
+typedef struct _EnumExtensions
+{
+	Packet* pResponse;
+	char* lpExtensionName;
+} EnumExtensions, * PEnumExtensions;
+
+BOOL ext_cmd_callback(LPVOID pState, LPVOID pData)
+{
+	PEnumExtensions pEnum = (PEnumExtensions)pState;
+	Command* command = NULL;
+
+	if (pEnum != NULL && pEnum->pResponse != NULL && pData != NULL)
+	{
+		PEXTENSION pExt = (PEXTENSION)pData;
+		if (pExt->name[0] != '\0' && pEnum->lpExtensionName != NULL && strcmp(pExt->name, pEnum->lpExtensionName) == 0)
+		{
+			dprintf("[LISTEXT] Found extension: %s", pExt->name);
+			for (command = pExt->start; command != pExt->end; command = command->next)
+			{
+				packet_add_tlv_string(pEnum->pResponse, TLV_TYPE_STRING, command->method);
+			}
+
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+DWORD request_core_enumextcmd(Remote* pRemote, Packet* pPacket)
+{
+	BOOL bResult = FALSE;
+	Packet* pResponse = packet_create_response(pPacket);
+
+	if (pResponse != NULL)
+	{
+		EnumExtensions enumExt;
+		enumExt.pResponse = pResponse;
+		enumExt.lpExtensionName = packet_get_tlv_value_string(pPacket, TLV_TYPE_STRING);
+
+		dprintf("[LISTEXTCMD] Listing extension commands for %s ...", enumExt.lpExtensionName);
+		// Start by enumerating the names of the extensions
+		bResult = list_enumerate(gExtensionList, ext_cmd_callback, &enumExt);
+
+		packet_add_tlv_uint(pResponse, TLV_TYPE_RESULT, ERROR_SUCCESS);
+		packet_transmit(pRemote, pResponse, NULL);
+	}
+
+	return ERROR_SUCCESS;
+}
 
 /*
  * Registers custom command handlers
@@ -38,7 +90,10 @@ VOID deregister_dispatch_routines(Remote * remote)
 			break;
 		}
 
-		extension->deinit(remote);
+		if (extension->deinit)
+		{
+			extension->deinit(remote);
+		}
 
 		free(extension);
 	}


### PR DESCRIPTION
Fix up my previously terrible PR for stageless stuff so that POSIX actually continues to work:

* Make sure POSIX has the new extension command enumeration function.
* Add support for deinit of extensions.
* Make sure extensions are tracked like they in Windows.
* Fix up a few export definitions.
* Stop using strncpy_s in POSIX code.

## Verification

- [ ] Windows and POSIX both build and run
- [ ] Extensions can be loaded in both (`use sniffer`)

