### PR TITLE
Fix up WinHTTP proxy implementation

### DIFF
--- a/source/common/core.c
+++ b/source/common/core.c
@@ -1335,6 +1335,16 @@ DWORD packet_transmit_via_http_winhttp(Remote *remote, Packet *packet, PacketReq
 
 		dprintf("[PACKET TRANSMIT] Request created: %x", hReq);
 
+		if (remote->proxyUser)
+		{
+			dprintf("[PACKET TRANSMIT] Setting proxy username to %S", remote->proxyUser);
+			dprintf("[PACKET TRANSMIT] Setting proxy password to %S", remote->proxyPass);
+			if (!WinHttpSetCredentials(hReq, WINHTTP_AUTH_TARGET_PROXY, WINHTTP_AUTH_SCHEME_BASIC, remote->proxyUser, remote->proxyPass, NULL))
+			{
+				dprintf("[PACKET TRANSMIT] Failed to set creds %u", GetLastError());
+			}
+		}
+
 		if (remote->transport == METERPRETER_TRANSPORT_HTTPS)
 		{
 			flags = SECURITY_FLAG_IGNORE_UNKNOWN_CA
@@ -1353,7 +1363,7 @@ DWORD packet_transmit_via_http_winhttp(Remote *remote, Packet *packet, PacketReq
 
 		if (!hRes)
 		{
-			dprintf("[PACKET RECEIVE] Failed HttpSendRequest: %d", GetLastError());
+			dprintf("[PACKET TRANSMIT] Failed HttpSendRequest: %d", GetLastError());
 			SetLastError(ERROR_NOT_FOUND);
 			break;
 		}
@@ -1796,6 +1806,16 @@ DWORD packet_receive_http_via_winhttp(Remote *remote, Packet **packet)
 			dprintf("[PACKET RECEIVE] Failed WinHttpOpenRequest: %d", GetLastError());
 			SetLastError(ERROR_NOT_FOUND);
 			break;
+		}
+
+		if (remote->proxyUser)
+		{
+			dprintf("[PACKET RECEIVE] Setting proxy username to %S", remote->proxyUser);
+			dprintf("[PACKET RECEIVE] Setting proxy password to %S", remote->proxyPass);
+			if (!WinHttpSetCredentials(hReq, WINHTTP_AUTH_TARGET_PROXY, WINHTTP_AUTH_SCHEME_BASIC, remote->proxyUser, remote->proxyPass, NULL))
+			{
+				dprintf("[PACKET RECEIVE] Failed to set creds %u", GetLastError());
+			}
 		}
 
 		if (remote->transport == METERPRETER_TRANSPORT_HTTPS)

--- a/source/common/remote.h
+++ b/source/common/remote.h
@@ -41,6 +41,8 @@ typedef struct _Remote
 	DWORD transport;              ///< Indicator of the transport in use for this session.
 	wchar_t* url;                 ///< Full URL in use during HTTP or HTTPS transport use.
 	wchar_t* uri;                 ///< URI endpoint in use during HTTP or HTTPS transport use.
+	wchar_t* proxyUser;           ///< Proxy server username (must be set for each request).
+	wchar_t* proxyPass;           ///< Proxy server password (must be set for each request).
 	HANDLE hInternet;             ///< Handle to the internet module for use with HTTP and HTTPS.
 	HANDLE hConnection;           ///< Handle to the HTTP or HTTPS connection.
 	unsigned char* pCertHash;     ///< Pointer to the 20-byte certificate hash to validate


### PR DESCRIPTION
These changes correct a few logic issues that were in place in the proxy handling for the WinHTTP implementation:

1. Proxy condition check was inverted.
1. Proxy username and password must be set on the request, and not the session handle.

## Verification

- [ ] reverse_http(s) payloads now correctly handle the proxy, proxy username and proxy password setings.

Testing of this can be done in a similar way to HD's PR here: https://github.com/rapid7/metasploit-framework/pull/4934

Note, the MSF-side changes that are listed in the following PR are required as well: https://github.com/rapid7/metasploit-framework/pull/5045