### PR TITLE
Remove second instance of the SSL check string

### DIFF
--- a/source/server/server_setup_win.c
+++ b/source/server/server_setup_win.c
@@ -777,7 +777,7 @@ Transport* transport_create_http(BOOL ssl, wchar_t* url, wchar_t* ua, wchar_t* p
 	ctx->ssl = ssl;
 
 	// only apply the cert hash if we're given one and it's not the global value
-	if (certHash && strncmp((char*)certHash, "METERPRETER_SSL_CERT_HASH", CERT_HASH_SIZE) != 0)
+	if (certHash && strncmp((char*)certHash + 12, "SSL_CERT_HASH", CERT_HASH_SIZE) != 0)
 	{
 		ctx->cert_hash = (PBYTE)malloc(sizeof(BYTE) * CERT_HASH_SIZE);
 		memcpy(ctx->cert_hash, certHash, CERT_HASH_SIZE);


### PR DESCRIPTION
The mechanism used for validation of the SSL cert string was the same as for many of the other global replacement options. However, the string value that was used for checking was also the same. The result was that the patch mechanism wasn't patching the right instance of the string.

DERP!

Why this hit stageless only I'm really not sure.

## Verification
- [ ] Stageless payload SSL cert validation works
- [ ] Staged payload SSL cert validation works

Thanks to @bcook-r7 for his thorough testing.

*Note:* This chunk of code is being heavily refactored in another branch, and the checking mechanism will be implemented correctly there as well.