### PR TITLE
relax the select timeout interval on the server socket

### DIFF
--- a/source/server/server_setup_posix.c
+++ b/source/server/server_setup_posix.c
@@ -430,7 +430,7 @@ static BOOL server_dispatch(Remote * remote, THREAD* dispatchThread)
 			dprintf("[DISPATCH] server dispatch thread signaled to terminate...");
 			break;
 		}
-		result = server_socket_poll(remote, 100);
+		result = server_socket_poll(remote, 500000);
 		if (result > 0) {
 			result = remote->transport->packet_receive(remote, &packet);
 			if (result != ERROR_SUCCESS) {


### PR DESCRIPTION
Currently, the select timeout on the server socket is 100 us, meaning that while idle, the process can wake up 10k times per second. This is especially bad on real hardware where the task switching is very fast. This switches the timeout to 0.5 second, reducing the idle CPU usage and seemingly increasing the reliability of posix meterpreter as well.

Tested with various test post test modules without failures. It is difficult to pinpoint the exact way to verify this fix, but something like this seemed to prove it out:

 * [ ]  run through the relevant modules under the test/scripts/test-sessions.rc and verified that the posix meterpreter did not die
 * [ ] check that interactivity and response time are unaffected
 * [x] check that cpu utilization is low, connect with strace and verify that it is not constantly waking up