### PR TITLE
Remove console and file output from kiwi

### DIFF
--- a/source/extensions/kiwi/mimikatz/mimikatz.c
+++ b/source/extensions/kiwi/mimikatz/mimikatz.c
@@ -138,8 +138,5 @@ DWORD mimikatz_init_or_clean(BOOL Init)
 		}
 	}
 
-	if (!Init)
-		kull_m_output_file(NULL);
-
 	return (DWORD)STATUS_SUCCESS;
 }

--- a/source/extensions/kiwi/mimikatz/modules/kuhl_m_standard.c
+++ b/source/extensions/kiwi/mimikatz/modules/kuhl_m_standard.c
@@ -11,7 +11,6 @@ const KUHL_M_C kuhl_m_c_standard[] = {
 	{kuhl_m_standard_cls,		L"cls",		L"Clear screen (doesn\'t work with redirections, like PsExec)"},
 	{kuhl_m_standard_answer,	L"answer",	L"Answer to the Ultimate Question of Life, the Universe, and Everything"},
 	{kuhl_m_standard_sleep,		L"sleep",	L"Sleep an amount of milliseconds"},
-	{kuhl_m_standard_log,		L"log",		L"Log mimikatz input/output to file"},
 	{kuhl_m_standard_base64,	L"base64",	L"Switch file output/base64 output"},
 	{kuhl_m_standard_version,	L"version",	L"Display some version informations"},
 };
@@ -56,13 +55,6 @@ NTSTATUS kuhl_m_standard_sleep(int argc, wchar_t * argv[])
 	kprintf(L"Sleep : %u ms... ", dwMilliseconds);
 	Sleep(dwMilliseconds);
 	kprintf(L"End !\n");
-	return STATUS_SUCCESS;
-}
-
-NTSTATUS kuhl_m_standard_log(int argc, wchar_t * argv[])
-{
-	PCWCHAR filename = (kull_m_string_args_byName(argc, argv, L"stop", NULL, NULL) ? NULL : (argc ? argv[0] : MIMIKATZ_DEFAULT_LOG));
-	kprintf(L"Using \'%s\' for logfile : %s\n", filename, kull_m_output_file(filename) ? L"OK" : L"KO");
 	return STATUS_SUCCESS;
 }
 

--- a/source/extensions/kiwi/mimikatz/modules/kuhl_m_standard.h
+++ b/source/extensions/kiwi/mimikatz/modules/kuhl_m_standard.h
@@ -15,7 +15,6 @@ NTSTATUS kuhl_m_standard_exit(int argc, wchar_t * argv[]);
 NTSTATUS kuhl_m_standard_cite(int argc, wchar_t * argv[]);
 NTSTATUS kuhl_m_standard_answer(int argc, wchar_t * argv[]);
 NTSTATUS kuhl_m_standard_sleep(int argc, wchar_t * argv[]);
-NTSTATUS kuhl_m_standard_log(int argc, wchar_t * argv[]);
 NTSTATUS kuhl_m_standard_base64(int argc, wchar_t * argv[]);
 NTSTATUS kuhl_m_standard_version(int argc, wchar_t * argv[]);
 

--- a/source/extensions/kiwi/modules/kull_m_output.c
+++ b/source/extensions/kiwi/modules/kull_m_output.c
@@ -3,7 +3,6 @@
 
 #define PRINT_BUFFER_SIZE 2048
 
-static FILE * logfile = NULL;
 static output_writer currentwriter = NULL;
 static wchar_t printbuffer[PRINT_BUFFER_SIZE];
 
@@ -14,42 +13,14 @@ VOID kull_m_output_set_writer(output_writer writer)
 
 void kprintf(PCWCHAR format, ...)
 {
-	va_list args;
-	va_start(args, format);
-
 	if (currentwriter)
 	{
+		va_list args;
+		va_start(args, format);
+
 		vswprintf_s(printbuffer, PRINT_BUFFER_SIZE, format, args);
 		currentwriter(printbuffer);
-	}
-	else
-	{
-		vwprintf(format, args);
-		fflush(stdout);
-	}
 
-	if (logfile)
-	{
-		vfwprintf(logfile, format, args);
+		va_end(args);
 	}
-	va_end(args);
-	fflush(logfile);
-}
-
-BOOL kull_m_output_file(PCWCHAR file)
-{
-	BOOL status = FALSE;
-	FILE * newlog = NULL;
-	errno_t result = 0;
-
-	if(file)
-		 result = _wfopen_s(&newlog, file, L"a");
-	
-	if(!result && (newlog || !file))
-	{
-		if(logfile)
-			fclose(logfile);
-		logfile = newlog;
-	}
-	return (!file || (!result && logfile));
 }

--- a/source/extensions/kiwi/modules/kull_m_output.h
+++ b/source/extensions/kiwi/modules/kull_m_output.h
@@ -11,5 +11,4 @@
 typedef void (*output_writer)(const wchar_t* newOutput);
 void kprintf(PCWCHAR format, ...);
 
-BOOL kull_m_output_file(PCWCHAR file);
 VOID kull_m_output_set_writer(output_writer writer);


### PR DESCRIPTION
This PR removes both log file and console output from kiwi. This is done so that those people who are unfortunate enough to migrate to a console app before running kiwi don't end up rendering all of the console output to a window that the user can see! Yes, this actually happened.

## Verification
- [x] The Kiwi extension works as it did before in both x64 and x86.
- [x] After migrating to a console app, the output of the underlying Mimikatz code should not be rendered to the console.