### PR TITLE
Add support for a 'sleep' command in Meterpreter

### DIFF
--- a/source/common/arch/posix/base_dispatch.c
+++ b/source/common/arch/posix/base_dispatch.c
@@ -259,14 +259,14 @@ DWORD remote_request_core_transport_add(Remote* remote, Packet* packet)
 	return result;
 }
 
-BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* pResult)
+BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* result)
 {
 	Transport* transport = NULL;
-	DWORD result = create_transport_from_request(remote, packet, &transport);
+	*result = create_transport_from_request(remote, packet, &transport);
 
-	packet_transmit_empty_response(remote, packet, result);
+	packet_transmit_empty_response(remote, packet, *result);
 
-	if (result == ERROR_SUCCESS) {
+	if (*result == ERROR_SUCCESS) {
 		remote->next_transport = transport;
 		// exit out of the dispatch loop.
 		return FALSE;

--- a/source/common/arch/posix/base_dispatch.c
+++ b/source/common/arch/posix/base_dispatch.c
@@ -271,6 +271,7 @@ BOOL remote_request_core_transport_sleep(Remote* remote, Packet* packet, DWORD* 
 	remote->next_transport = remote->transport;
 
 	packet_transmit_empty_response(remote, packet, ERROR_SUCCESS);
+	*result = ERROR_SUCCESS;
 
 	// exit out of the dispatch loop
 	return FALSE;

--- a/source/common/arch/posix/base_dispatch.c
+++ b/source/common/arch/posix/base_dispatch.c
@@ -259,6 +259,23 @@ DWORD remote_request_core_transport_add(Remote* remote, Packet* packet)
 	return result;
 }
 
+BOOL remote_request_core_transport_sleep(Remote* remote, Packet* packet, DWORD* result)
+{
+	// we'll reuse the comm timeout TLV for this purpose
+	DWORD seconds = packet_get_tlv_value_uint(packet, TLV_TYPE_TRANS_COMM_TIMEOUT);
+
+	dprintf("[DISPATCH] request received to sleep for %u seconds", seconds);
+
+	// to sleep, we simply jump to the same transport, with a delay
+	remote->next_transport_wait = seconds;
+	remote->next_transport = remote->transport;
+
+	packet_transmit_empty_response(remote, packet, ERROR_SUCCESS);
+
+	// exit out of the dispatch loop
+	return FALSE;
+}
+
 BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* result)
 {
 	Transport* transport = NULL;

--- a/source/common/arch/win/i386/base_dispatch.c
+++ b/source/common/arch/win/i386/base_dispatch.c
@@ -302,6 +302,23 @@ DWORD remote_request_core_transport_add(Remote* remote, Packet* packet)
 	return result;
 }
 
+BOOL remote_request_core_transport_sleep(Remote* remote, Packet* packet, DWORD* result)
+{
+	// we'll reuse the comm timeout TLV for this purpose
+	DWORD seconds = packet_get_tlv_value_uint(packet, TLV_TYPE_TRANS_COMM_TIMEOUT);
+
+	dprintf("[DISPATCH] request received to sleep for %u seconds", seconds);
+
+	// to sleep, we simply jump to the same transport, with a delay
+	remote->next_transport_wait = seconds;
+	remote->next_transport = remote->transport;
+
+	packet_transmit_empty_response(remote, packet, ERROR_SUCCESS);
+
+	// exit out of the dispatch loop
+	return FALSE;
+}
+
 BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* result)
 {
 	Transport* transport = NULL;

--- a/source/common/arch/win/i386/base_dispatch.c
+++ b/source/common/arch/win/i386/base_dispatch.c
@@ -314,6 +314,7 @@ BOOL remote_request_core_transport_sleep(Remote* remote, Packet* packet, DWORD* 
 	remote->next_transport = remote->transport;
 
 	packet_transmit_empty_response(remote, packet, ERROR_SUCCESS);
+	*result = ERROR_SUCCESS;
 
 	// exit out of the dispatch loop
 	return FALSE;

--- a/source/common/arch/win/i386/base_dispatch.c
+++ b/source/common/arch/win/i386/base_dispatch.c
@@ -302,14 +302,14 @@ DWORD remote_request_core_transport_add(Remote* remote, Packet* packet)
 	return result;
 }
 
-BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* pResult)
+BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* result)
 {
 	Transport* transport = NULL;
-	DWORD result = create_transport_from_request(remote, packet, &transport);
+	*result = create_transport_from_request(remote, packet, &transport);
 
-	packet_transmit_empty_response(remote, packet, result);
+	packet_transmit_empty_response(remote, packet, *result);
 
-	if (result == ERROR_SUCCESS)
+	if (*result == ERROR_SUCCESS)
 	{
 		remote->next_transport = transport;
 		// exit out of the dispatch loop.

--- a/source/common/base.c
+++ b/source/common/base.c
@@ -29,8 +29,9 @@ extern DWORD remote_request_core_transport_setcerthash(Remote* remote, Packet* p
 // POSIX support coming soon
 #endif
 
+extern BOOL remote_request_core_transport_sleep(Remote* remote, Packet* packet, DWORD* result);
 extern DWORD remote_request_core_transport_list(Remote* remote, Packet* packet);
-extern BOOL remote_request_core_transport_change(Remote *remote, Packet *packet, DWORD* pResult);
+extern BOOL remote_request_core_transport_change(Remote* remote, Packet* packet, DWORD* result);
 extern BOOL remote_request_core_transport_next(Remote* remote, Packet* packet, DWORD* result);
 extern BOOL remote_request_core_transport_prev(Remote* remote, Packet* packet, DWORD* result);
 extern DWORD remote_request_core_transport_add(Remote* remote, Packet* packet);
@@ -93,6 +94,7 @@ Command baseCommands[] =
 	COMMAND_REQ("core_transport_setcerthash", remote_request_core_transport_setcerthash),
 #endif
 	COMMAND_REQ("core_transport_list", remote_request_core_transport_list),
+	COMMAND_INLINE_REQ("core_transport_sleep", remote_request_core_transport_sleep),
 	COMMAND_INLINE_REQ("core_transport_change", remote_request_core_transport_change),
 	COMMAND_INLINE_REQ("core_transport_next", remote_request_core_transport_next),
 	COMMAND_INLINE_REQ("core_transport_prev", remote_request_core_transport_prev),

--- a/source/common/remote.h
+++ b/source/common/remote.h
@@ -110,6 +110,7 @@ typedef struct _Remote
 
 	Transport* transport;                 ///! Pointer to the currently used transport mechanism in a circular list of transports
 	Transport* next_transport;            ///! Set externally when transports are requested to be changed.
+	DWORD next_transport_wait;            ///! Number of seconds to wait before going to the next transport (used for sleeping).
 
 	MetsrvConfig* orig_config;            ///! Pointer to the original configuration.
 

--- a/source/server/server_setup_posix.c
+++ b/source/server/server_setup_posix.c
@@ -1351,6 +1351,13 @@ DWORD server_setup(MetsrvConfig* config)
 			dprintf("[TRANS] Moving transport from 0x%p to 0x%p", remote->transport, remote->next_transport);
 			remote->transport = remote->next_transport;
 			remote->next_transport = NULL;
+
+			if (remote->next_transport_wait > 0) {
+				dprintf("[TRANS] Sleeping for %u seconds ...", remote->next_transport_wait);
+				sleep(remote->next_transport_wait);
+				// the wait is a once-off thing, needs to be reset each time
+				remote->next_transport_wait = 0;
+			}
 		}
 		else {
 			// move to the next one in the list

--- a/source/server/server_setup_win.c
+++ b/source/server/server_setup_win.c
@@ -333,7 +333,7 @@ DWORD server_setup(MetsrvConfig* config)
 
 			// the first transport should match the transport that we initially connected on.
 			// If it's TCP comms, we need to wire that up.
-			if (config->session.comms_fd)
+			if (remote->transport->type == METERPRETER_TRANSPORT_SSL && config->session.comms_fd)
 			{
 				((TcpTransportContext*)remote->transport->ctx)->fd = (SOCKET)config->session.comms_fd;
 			}

--- a/source/server/server_setup_win.c
+++ b/source/server/server_setup_win.c
@@ -430,6 +430,14 @@ DWORD server_setup(MetsrvConfig* config)
 					dprintf("[TRANS] Moving transport from 0x%p to 0x%p", remote->transport, remote->next_transport);
 					remote->transport = remote->next_transport;
 					remote->next_transport = NULL;
+
+					if (remote->next_transport_wait > 0)
+					{
+						dprintf("[TRANS] Sleeping for %u seconds ...", remote->next_transport_wait);
+						Sleep(remote->next_transport_wait * 1000);
+						// the wait is a once-off thing, needs to be reset each time
+						remote->next_transport_wait = 0;
+					}
 				}
 				else
 				{

--- a/source/server/win/server_transport_winhttp.c
+++ b/source/server/win/server_transport_winhttp.c
@@ -561,7 +561,6 @@ static DWORD server_dispatch_http(Remote* remote, THREAD* dispatchThread)
 	DWORD ecount = 0;
 	DWORD delay = 0;
 	Transport* transport = remote->transport;
-	HttpTransportContext* ctx = (HttpTransportContext*)remote->transport->ctx;
 
 	while (running)
 	{

--- a/source/server/win/server_transport_winhttp.c
+++ b/source/server/win/server_transport_winhttp.c
@@ -475,7 +475,7 @@ static BOOL server_init_http(Transport* transport)
 	dprintf("[WINHTTP] Initialising ...");
 
 	// configure proxy
-	if (ctx->proxy && wcscmp(ctx->proxy, L"METERPRETER_PROXY") != 0)
+	if (ctx->proxy)
 	{
 		dprintf("[DISPATCH] Configuring with proxy: %S", ctx->proxy);
 		ctx->internet = WinHttpOpen(ctx->ua, WINHTTP_ACCESS_TYPE_NAMED_PROXY, ctx->proxy, WINHTTP_NO_PROXY_BYPASS, 0);
@@ -708,22 +708,22 @@ Transport* transport_create_http(MetsrvTransportHttp* config)
 	memset(transport, 0, sizeof(Transport));
 	memset(ctx, 0, sizeof(HttpTransportContext));
 
-	SAFE_FREE(ctx->ua);
-	if (config->ua)
+	dprintf("[TRANS HTTP] Given ua: %S", config->ua);
+	if (config->ua[0])
 	{
 		ctx->ua = _wcsdup(config->ua);
 	}
-	SAFE_FREE(ctx->proxy);
+	dprintf("[TRANS HTTP] Given proxy host: %S", config->proxy.hostname);
 	if (config->proxy.hostname[0])
 	{
 		ctx->proxy = _wcsdup(config->proxy.hostname);
 	}
-	SAFE_FREE(ctx->proxy_user);
+	dprintf("[TRANS HTTP] Given proxy user: %S", config->proxy.username);
 	if (config->proxy.username[0])
 	{
 		ctx->proxy_user = _wcsdup(config->proxy.username);
 	}
-	SAFE_FREE(ctx->proxy_pass);
+	dprintf("[TRANS HTTP] Given proxy pass: %S", config->proxy.password);
 	if (config->proxy.password[0])
 	{
 		ctx->proxy_pass = _wcsdup(config->proxy.password);


### PR DESCRIPTION
This PR relies on the work done in #156, and hence that needs to be landed first.

This PR contains code that adds support for the `sleep` command. Full details, along with repro and validation steps, are available at the MSF PR that is located here: https://github.com/rapid7/metasploit-framework/pull/5339

Thanks!