### PR TITLE
Utilise IE configuration for proxies where possible

### DIFF
--- a/source/common/config.h
+++ b/source/common/config.h
@@ -16,11 +16,11 @@
 
 #ifdef _WIN32
 typedef wchar_t CHARTYPE;
-typedef CHARTYPE* STRTYPE;
 #else
 typedef char CHARTYPE;
-typedef CHARTYPE* STRTYPE;
 #endif
+typedef CHARTYPE* STRTYPE;
+typedef CHARTYPE const * CSTRTYPE;
 
 typedef struct _MetsrvSession
 {

--- a/source/common/remote.h
+++ b/source/common/remote.h
@@ -64,11 +64,15 @@ typedef struct _HttpTransportContext
 	HANDLE connection;                    ///! Handle to the HTTP or HTTPS connection.
 	unsigned char* cert_hash;             ///! Pointer to the 20-byte certificate hash to validate
 
+	CSTRTYPE url;                         ///! Pointer to the URL stored with the transport.
 	STRTYPE ua;                           ///! User agent string.
 	STRTYPE uri;                          ///! UUID encoded as a URI.
 	STRTYPE proxy;                        ///! Proxy details.
 	STRTYPE proxy_user;                   ///! Proxy username.
 	STRTYPE proxy_pass;                   ///! Proxy password.
+
+	BOOL proxy_configured;                ///! Indication of whether the proxy has been configured.
+	LPVOID proxy_for_url;                 ///! Pointer to the proxy for the current url (if required).
 } HttpTransportContext;
 
 typedef struct _Transport

--- a/source/server/win/server_transport_winhttp.c
+++ b/source/server/win/server_transport_winhttp.c
@@ -34,7 +34,76 @@ static HINTERNET get_winhttp_req(HttpTransportContext *ctx, const char *directio
 		return NULL;
 	}
 
-	if (ctx->proxy_user)
+	// if no proxy is set, we should look to see if we can (and should) use the system
+	// proxy settings for the given user.
+	if (!ctx->proxy)
+	{
+		if (!ctx->proxy_configured)
+		{
+			WINHTTP_CURRENT_USER_IE_PROXY_CONFIG ieConfig = { 0 };
+			if (WinHttpGetIEProxyConfigForCurrentUser(&ieConfig))
+			{
+				dprintf("[PROXY] Got IE configuration");
+				if (ieConfig.fAutoDetect && ieConfig.lpszAutoConfigUrl)
+				{
+					WINHTTP_AUTOPROXY_OPTIONS autoProxyOpts = { 0 };
+					WINHTTP_PROXY_INFO proxyInfo = { 0 };
+
+					dprintf("[PROXY] IE config set to autodetect with URL %S", ieConfig.lpszAutoConfigUrl);
+
+					autoProxyOpts.dwFlags = WINHTTP_AUTOPROXY_AUTO_DETECT | WINHTTP_AUTOPROXY_CONFIG_URL;
+					autoProxyOpts.dwAutoDetectFlags = WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+					autoProxyOpts.fAutoLogonIfChallenged = TRUE;
+					autoProxyOpts.lpszAutoConfigUrl = ieConfig.lpszAutoConfigUrl;
+
+					if (WinHttpGetProxyForUrl(ctx->internet, ctx->url, &autoProxyOpts, &proxyInfo))
+					{
+						ctx->proxy_for_url = malloc(sizeof(WINHTTP_PROXY_INFO));
+						memcpy(ctx->proxy_for_url, &proxyInfo, sizeof(WINHTTP_PROXY_INFO));
+					}
+				}
+				else if (ieConfig.lpszProxy)
+				{
+					WINHTTP_PROXY_INFO* proxyInfo = (WINHTTP_PROXY_INFO*)calloc(1, sizeof(WINHTTP_PROXY_INFO));
+					ctx->proxy_for_url = proxyInfo;
+
+					dprintf("[PROXY] IE config set to proxy %S with bypass %S", ieConfig.lpszProxy, ieConfig.lpszProxyBypass);
+
+					proxyInfo->dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
+					proxyInfo->lpszProxy = ieConfig.lpszProxy;
+					proxyInfo->lpszProxyBypass = ieConfig.lpszProxyBypass;
+
+					// stop the cleanup code from removing these as we're using them behind the scenes and they will
+					// be freed later instead.
+					ieConfig.lpszProxy = NULL;
+					ieConfig.lpszProxyBypass = NULL;;
+				}
+
+				if (ieConfig.lpszAutoConfigUrl)
+				{
+					GlobalFree(ieConfig.lpszAutoConfigUrl);
+				}
+				if (ieConfig.lpszProxy)
+				{
+					GlobalFree(ieConfig.lpszProxy);
+				}
+				if (ieConfig.lpszProxyBypass)
+				{
+					GlobalFree(ieConfig.lpszProxyBypass);
+				}
+			}
+
+			// mark as "configured" so we don't attempt to do this horrible PoS mess again.
+			ctx->proxy_configured = TRUE;
+		}
+
+		if (ctx->proxy_for_url &&
+			!WinHttpSetOption(hReq, WINHTTP_OPTION_PROXY, ctx->proxy_for_url, sizeof(WINHTTP_PROXY_INFO)))
+		{
+			dprintf("[%s] Unable to set proxy options: %u", GetLastError());
+		}
+	}
+	else if (ctx->proxy_user)
 	{
 		dprintf("[%s] Setting proxy username to %S", direction, ctx->proxy_user);
 		dprintf("[%s] Setting proxy password to %S", direction, ctx->proxy_pass);
@@ -651,6 +720,19 @@ static void transport_destroy_http(Transport* transport)
 			SAFE_FREE(ctx->proxy_user);
 			SAFE_FREE(ctx->ua);
 			SAFE_FREE(ctx->uri);
+			if (ctx->proxy_for_url)
+			{
+				WINHTTP_PROXY_INFO* proxyInfo = (WINHTTP_PROXY_INFO*)ctx->proxy_for_url;
+				if (proxyInfo->lpszProxy)
+				{
+					GlobalFree(proxyInfo->lpszProxy);
+				}
+				if (proxyInfo->lpszProxyBypass)
+				{
+					GlobalFree(proxyInfo->lpszProxyBypass);
+				}
+			}
+			SAFE_FREE(ctx->proxy_for_url);
 		}
 		SAFE_FREE(transport->url);
 		SAFE_FREE(transport->ctx);
@@ -750,7 +832,7 @@ Transport* transport_create_http(MetsrvTransportHttp* config)
 	transport->timeouts.retry_total = config->common.retry_total;
 	transport->timeouts.retry_wait = config->common.retry_wait;
 	transport->type = ctx->ssl ? METERPRETER_TRANSPORT_HTTPS : METERPRETER_TRANSPORT_HTTP;
-	transport->url = _wcsdup(config->common.url);
+	ctx->url = transport->url = _wcsdup(config->common.url);
 	transport->packet_transmit = packet_transmit_via_http;
 	transport->server_dispatch = server_dispatch_http;
 	transport->transport_init = server_init_http;


### PR DESCRIPTION
Note: This PR requires https://github.com/rapid7/metasploit-framework/pull/5300 on the MSF side to function.

After the WinHTTP work we did recently the automatic proxy support inside Meterpreter effectively stopped working. This meant that those people who used `reverse_http/s` payloads would get an initial connection back to MSF but from there the shell would be dead.

The reason was that WinHTTP doesn't adopt the default configuration for the current user like the WinInet API does. What was required was more work to query the IE settings and implement them separately.

This PR adds the default proxy support back to Meterpreter so that any system configuration for the user is applied in the way that it used to be. This doesn't add support for proxies that require manual authentication, but we didn't have that for WinInet either.

Once this has been verified and landed, I'll port these changes to the `reverse_winhttp/s` stagers as well.

## Verification
- [x] Make sure that payloads without proxy configurations still work.
- [x] Make sure that payloads _with_ **manual** proxy configurations still work (ie. set the `PayloadProxyHost`, `PayloadProxyUser` ... etc).
- [x] Make sure that payloads _without_ manual proxy configurations utilise the proxy configuration that it set up on the target IE configuration, if there is one.
- [x] Make sure that payloads that are configured with manual proxy settings utilise those settings instead of the ones set by the IE configuration.

Ping @Meatballs1 for help with verifying that this works please!