### PR TITLE
Fixup bare met_svc var name

### DIFF
--- a/source/extensions/bare/bare.c
+++ b/source/extensions/bare/bare.c
@@ -24,7 +24,7 @@ Command customCommands[] =
  */
 DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 {
-	hMetSrv = remote->hMetSrv;
+	hMetSrv = remote->met_srv;
 
 	command_register_all(customCommands);
 


### PR DESCRIPTION
This was incorrect causing the bare extension (and extensions based off it) to fail. 