### PR TITLE
Fix handling of UUIDs in Meterpreter

### DIFF
--- a/source/common/config.h
+++ b/source/common/config.h
@@ -9,7 +9,7 @@
 #define CERT_HASH_SIZE 20
 #define URL_SIZE 512
 #define UA_SIZE 256
-#define UUID_SIZE 64
+#define UUID_SIZE 16
 #define PROXY_HOST_SIZE 128
 #define PROXY_USER_SIZE 64
 #define PROXY_PASS_SIZE 64
@@ -27,7 +27,7 @@ typedef struct _MetsrvSession
 	DWORD comms_fd;                       ///! Socket handle for communications (if there is one).
 	DWORD exit_func;                      ///! Exit func identifier for when the session ends.
 	int expiry;                           ///! The total number of seconds to wait before killing off the session.
-	CHARTYPE uuid[UUID_SIZE];             ///! UUID
+	BYTE uuid[UUID_SIZE];                 ///! UUID
 } MetsrvSession;
 
 typedef struct _MetsrvTransportCommon

--- a/source/common/core.h
+++ b/source/common/core.h
@@ -160,7 +160,7 @@ typedef enum
 
 	// session/machine identification
 	TLV_TYPE_MACHINE_ID          = TLV_VALUE(TLV_META_TYPE_STRING,    460),   ///! Represents a machine identifier.
-	TLV_TYPE_UUID                = TLV_VALUE(TLV_META_TYPE_STRING,    461),   ///! Represents a session identifier.
+	TLV_TYPE_UUID                = TLV_VALUE(TLV_META_TYPE_RAW,       461),   ///! Represents a UUID.
 
 	// Cryptography
 	TLV_TYPE_CIPHER_NAME         = TLV_VALUE(TLV_META_TYPE_STRING,    500),   ///! Represents the name of a cipher.

--- a/source/server/posix/remote_dispatch.c
+++ b/source/server/posix/remote_dispatch.c
@@ -159,7 +159,7 @@ DWORD request_core_uuid(Remote* remote, Packet* packet) {
 	Packet* response = packet_create_response(packet);
 
 	if (response) {
-		packet_add_tlv_wstring(response, TLV_TYPE_UUID, remote->orig_config->session.uuid);
+		packet_add_tlv_raw(response, TLV_TYPE_UUID, remote->orig_config->session.uuid, UUID_SIZE);
 
 		packet_transmit_response(ERROR_SUCCESS, remote, response);
 	}

--- a/source/server/server_setup_win.c
+++ b/source/server/server_setup_win.c
@@ -218,7 +218,7 @@ static void config_create(Remote* remote, MetsrvConfig** config, LPDWORD size)
 	dprintf("[CONFIG] preparing the configuration");
 
 	// start by preparing the session.
-	memcpy(sess->uuid, remote->orig_config->session.uuid, sizeof(sess->uuid));
+	memcpy(sess->uuid, remote->orig_config->session.uuid, UUID_SIZE);
 	sess->expiry = remote->sess_expiry_end - current_unix_timestamp();
 	sess->exit_func = EXITFUNC_THREAD; // migration we default to this.
 
@@ -291,6 +291,12 @@ DWORD server_setup(MetsrvConfig* config)
 	dprintf("[SESSION] Comms Fd: %u", config->session.comms_fd);
 	dprintf("[SESSION] UUID: %S", config->session.uuid);
 	dprintf("[SESSION] Expiry: %u", config->session.expiry);
+
+	dprintf("[SERVER] UUID: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+		config->session.uuid[0], config->session.uuid[1], config->session.uuid[2], config->session.uuid[3],
+		config->session.uuid[4], config->session.uuid[5], config->session.uuid[6], config->session.uuid[7],
+		config->session.uuid[8], config->session.uuid[9], config->session.uuid[10], config->session.uuid[11],
+		config->session.uuid[12], config->session.uuid[13], config->session.uuid[14], config->session.uuid[15]);
 
 	// if hAppInstance is still == NULL it means that we havent been
 	// reflectivly loaded so we must patch in the hAppInstance value

--- a/source/server/win/remote_dispatch.c
+++ b/source/server/win/remote_dispatch.c
@@ -206,7 +206,7 @@ DWORD request_core_uuid(Remote* remote, Packet* packet)
 
 	if (response)
 	{
-		packet_add_tlv_wstring(response, TLV_TYPE_UUID, remote->orig_config->session.uuid);
+		packet_add_tlv_raw(response, TLV_TYPE_UUID, remote->orig_config->session.uuid, UUID_SIZE);
 
 		packet_transmit_response(ERROR_SUCCESS, remote, response);
 	}


### PR DESCRIPTION
The original implementation assumed that the UUIDs were coming through a strings, but this was changed at some point to use the 16-byte UUID format straight out of MSF.

This was causing issues when UUIDs had null bytes in them because the UUID was being truncated and the result was that UUIDs that were being parsed in MSF were too small, resulting in exceptions.

This PR fixes this by:

* Making UUIDs exactly 16 bytes.
* Changing the TLV type to raw.
* Not use string functions when sending the UUID to Metasploit.

Please see the accompanying MSF PR for more details: https://github.com/rapid7/metasploit-framework/pull/5357