### PR TITLE
Implement a sleep in windows that lasts longer

### DIFF
--- a/source/common/common.h
+++ b/source/common/common.h
@@ -181,6 +181,8 @@ void real_dprintf(char *filename, int line, const char *function, char *format, 
 
 #ifdef _WIN32
 
+VOID sleep(DWORD seconds);
+
 #ifdef DEBUGTRACE
 #define dprintf(...) real_dprintf(__VA_ARGS__)
 #if DEBUGTRACE == 1

--- a/source/server/server_setup_win.c
+++ b/source/server/server_setup_win.c
@@ -439,7 +439,9 @@ DWORD server_setup(MetsrvConfig* config)
 					if (remote->next_transport_wait > 0)
 					{
 						dprintf("[TRANS] Sleeping for %u seconds ...", remote->next_transport_wait);
-						Sleep(remote->next_transport_wait * 1000);
+
+						sleep(remote->next_transport_wait);
+						
 						// the wait is a once-off thing, needs to be reset each time
 						remote->next_transport_wait = 0;
 					}

--- a/source/server/win/server_transport_tcp.c
+++ b/source/server/win/server_transport_tcp.c
@@ -40,7 +40,7 @@ static DWORD reverse_tcp_run(SOCKET reverseSocket, SOCKADDR* sockAddr, int sockA
 		}
 
 		dprintf("[TCP RUN] Connection failed, sleeping for %u s", retryWait);
-		Sleep(retryWait * 1000);
+		sleep(retryWait);
 	} while (((DWORD)current_unix_timestamp() - (DWORD)start) < retryTotal);
 
 	if (result == SOCKET_ERROR)
@@ -149,7 +149,7 @@ static DWORD reverse_tcp6(const char* host, const char* service, ULONG scopeId, 
 		}
 
 		dprintf("[TCP RUN] Connection failed, sleeping for %u s", retryWait);
-		Sleep(retryWait * 1000);
+		sleep(retryWait);
 	} while (((DWORD)current_unix_timestamp() - (DWORD)start) < retryTotal);
 
 	closesocket(socketHandle);


### PR DESCRIPTION
There were **valid** concerns that the use of `Sleep()` on Windows wasn't going to provide enough time given that the limit of using a `DWORD` for timeouts that are specified in milliseconds result in a limitation of approximately 49 days (thanks @bcook-r7 for pointing that out).

This PR uses the hidden `NtDelayExecution` function that is in `ntdll.dll` instead of `Sleep` where possible and falls back on `Sleep` if not found. This function can sleep for _way_ longer (see code comments).

## Verification

- [ ] Issuing the  `sleep` command still works as it does before.
- [ ] Issuing the `sleep` command with a value > 50 days and < 22,000 years (such as `4752000` seconds) "works" (I pity the tester). Make sure that the session expiry time is updated so that when the sleep returns it doesn't just show down immediately.