### PR TITLE
Fix clipboard file size handling

### DIFF
--- a/source/extensions/extapi/clipboard.c
+++ b/source/extensions/extapi/clipboard.c
@@ -377,7 +377,7 @@ VOID dump_clipboard_capture(Packet* pResponse, ClipboardCapture* pCapture, BOOL 
 			dprintf("[EXTAPI CLIPBOARD] Adding path %s", pFile->lpPath);
 			packet_add_tlv_string(file, TLV_TYPE_EXT_CLIPBOARD_TYPE_FILE_NAME, pFile->lpPath);
 
-			dprintf("[EXTAPI CLIPBOARD] Adding size %llu", htonq(pFile->qwSize));
+			dprintf("[EXTAPI CLIPBOARD] Adding size %llu", pFile->qwSize);
 			packet_add_tlv_qword(file, TLV_TYPE_EXT_CLIPBOARD_TYPE_FILE_SIZE, pFile->qwSize);
 
 			dprintf("[EXTAPI CLIPBOARD] Adding group");
@@ -709,7 +709,7 @@ DWORD capture_clipboard(BOOL bCaptureImageData, ClipboardCapture** ppCapture)
 							{
 								if (pGetFileSizeEx(hSourceFile, &largeInt))
 								{
-									pFile->qwSize = htonq(largeInt.QuadPart);
+									pFile->qwSize = largeInt.QuadPart;
 								}
 
 								pCloseHandle(hSourceFile);


### PR DESCRIPTION
This is a small fix to `extapi`'s clipboard functionality. When files are captured on the clipboard, the file sizes are incorrectly reported because they were being stored _after_ a call to `htonq`. When sending the value down the wire, a call to `packet_add_tlv_qword` was being used, which by itself does another call to `htonq`, resulting in the bytes being reversed again.

This patch removes the unnecessary manual call, and results in correctly reported file sizes when the clipboard is in use.

## Verification

- [x] Get a windows meterpreter session going.
- [x] Load extapi via `use extapi`.
- [x] On the target, select any file on the file system and press `CTRL+C`.
- [x] In the Meterpreter session, execute `clipboard_get_data`.
- [x] Verify that the reported file size is correct.