### PR TITLE
Add a signpost for users to find the new merged repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-Current `master` branch: ![Meterpreter Build Status][build_icon]
+# This repository has been merged into metasploit-payloads
+
+Please note that this repository has been merged into a unified repository for
+meterpreters: https://github.com/rapid7/metasploit-payloads
+
+The history has been preserved, along with prehistory from metasploit-framework:
+https://github.com/rapid7/metasploit-payloads/tree/master/c/meterpreter
+
+If you have any local branches, please rebase them on the new repository. See
+https://github.com/rapid7/meterpreter/issues/110 for discussion of why we
+merged these repositories back together.
 
 meterpreter >
 =============


### PR DESCRIPTION
This just updates the README so users can find the new repo.

I will handle cleaning up and mergeing the two remaining PRs, so there does not need to be any action there. For other forks or future PRs, please switch to using metasploit-payloads now.