### PR TITLE
CONTRIBUTING.md that points to metasploit-payloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to Meterpreter
+
+Thanks for your interest in contributing to Meterpreter, but this
+repository is now deprecated. Please see the [README.md][readme] and
+[issue #110][issue-110] for more details. You almost certainly are
+looking for the metasploit-payloads repository instead, which can be
+found here:
+
+https://github.com/rapid7/metasploit-payloads
+
+Good luck!
+
+[issue-110]:https://github.com/rapid7/meterpreter/issues/110
+[readme]:https://github.com/rapid7/meterpreter/blob/master/README.md


### PR DESCRIPTION
When you have a CONTRIBUTING.md, there's an ever so subtle link provided on the issues page that lightly encourages people to read it before filing an issue. Why it doesn't do the same for pull requests is beyond my ken, but it's at least something.

This is written assuming that the current README.md and #110 are not a lie.

## Validation

- [ ] Read CONTRIBUTING.md and get dissuaded from opening with an issue

## Post-Landing
- [ ] See the "guidelines for contributing" warning box on the issues page.
- [ ] Once the issue bookkeeping is done, close issues on this repo.
- [ ] Figure out when to delete this repo entirely: six months to never (having the old issues live for a while is handy but will eventually no longer be).

